### PR TITLE
Adjust contract instantiation to match Core constructor

### DIFF
--- a/test/makeOrder.js
+++ b/test/makeOrder.js
@@ -21,6 +21,8 @@ contract('Net Asset Value', (accounts) => {
   // Test constants
   const OWNER = accounts[0];
   const PORTFOLIO_NAME = 'Melon Portfolio';
+  const PORTFOLIO_SYMBOL = 'MLN-P';
+  const PORTFOLIO_DECIMALS = 18;
   const NOT_OWNER = accounts[1];
   const NUM_OFFERS = 1;
   const ALLOWANCE_AMOUNT = constants.PREMINED_AMOUNT / 10;
@@ -93,8 +95,10 @@ contract('Net Asset Value', (accounts) => {
 
     it('Deploy smart contract', (done) => {
       Core.new(
-        PORTFOLIO_NAME,
         OWNER,
+        PORTFOLIO_NAME,
+        PORTFOLIO_SYMBOL,
+        PORTFOLIO_DECIMALS,
         universeContract.address,
         subscribeContract.address,
         redeemContract.address,

--- a/test/subscribe.js
+++ b/test/subscribe.js
@@ -20,6 +20,8 @@ contract('Subscribe', (accounts) => {
   const INVESTOR = accounts[0];
   const OWNER = accounts[1];
   const PORTFOLIO_NAME = 'Melon Portfolio';
+  const PORTFOLIO_SYMBOL = 'MLN-P';
+  const PORTFOLIO_DECIMALS = 18;
   const ALLOWANCE_AMOUNT = constants.PREMINED_AMOUNT / 10;
 
   // Test globals
@@ -53,8 +55,10 @@ contract('Subscribe', (accounts) => {
 
     it('Deploy smart contract', (done) => {
       Core.new(
-        PORTFOLIO_NAME,
         OWNER,
+        PORTFOLIO_NAME,
+        PORTFOLIO_SYMBOL,
+        PORTFOLIO_DECIMALS,
         universeContract.address,
         subscribeContract.address,
         redeemContract.address,


### PR DESCRIPTION
The tests in makeOrder.js and subscribe.js did not reflect the new Core.sol constructor. Adjusted the creation of contracts in the test files as in nav.js and version.js.