### PR TITLE
Release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.3.2]
 
 ### Added
-- Fixed: #104
 - Function to change descriptive information in asset registrar
 - Contract draft for contribution
 - FundHistory
 - Interfaces
 - ExchagneAdapter
 - Actual implementation of SimpleMarket - OasisDex exchange
+- InternalAccounting cleanup
+- Natspecs comments
+- Participation example uPort
+- Competition contract
+- LogError event in Fund
+- Gross asset calculations accounts for externally held assets
 
 ### Changed
 - Naming: Vault -> Fund
 - Naming: subscribe -> requestSubscription in Fund
 - Naming: redeem -> requestRedemption in Fund
+- Mappings to arrays where sensible
 
 ### Removed
 - Information struct in Fund
+- FundHistory dependency
+- Logger
+
+## Fixes
+- Fixed: #104
+- Fixed makeOrder issue
 
 ## [0.3.1]
 

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -412,16 +412,9 @@ contract Fund is DBC, Owned, Shares, FundInterface {
     function executeRequest(uint requestId)
         external
         pre_cond(notShutDown())
-        pre_cond(isSubscribe(requests[requestId].requestType) ||
-            isRedeem(requests[requestId].requestType))
-        pre_cond(notLessThan(
-            now,
-            requests[requestId].timestamp.add(module.datafeed.getInterval())
-        ))
-        pre_cond(notLessThan(
-            module.datafeed.getLastUpdateId(),
-            requests[requestId].lastFeedUpdateId + 2
-        ))
+        pre_cond(isSubscribe(requests[requestId].requestType) || isRedeem(requests[requestId].requestType))
+        pre_cond(notLessThan(now, requests[requestId].timestamp.add(module.datafeed.getInterval())))
+        pre_cond(notLessThan(module.datafeed.getLastUpdateId(), requests[requestId].lastFeedUpdateId + 2))
     {
         // Time and updates have passed
         Request request = requests[requestId];
@@ -443,8 +436,7 @@ contract Fund is DBC, Owned, Shares, FundInterface {
 
     function cancelRequest(uint requestId)
         external
-        pre_cond(isSubscribe(requests[requestId].requestType) ||
-            isRedeem(requests[requestId].requestType)) // TODO: Check validity of this
+        pre_cond(isSubscribe(requests[requestId].requestType) || isRedeem(requests[requestId].requestType))
         pre_cond(requests[requestId].owner == msg.sender || isShutDown)
     {
         Request request = requests[requestId];
@@ -607,6 +599,8 @@ contract Fund is DBC, Owned, Shares, FundInterface {
     }
 
     //TODO: add previousHoldings
+    /// @param sellAsset Asset (as registred in Asset registrar) to be sold
+    /// @param buyAsset Asset (as registred in Asset registrar) to be bought
     function closeOpenOrders(address sellAsset, address buyAsset)
         constant
     {

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -525,8 +525,8 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         if (isFalse(module.datafeed.existsData(sellAsset, buyAsset))) { LogError(0); return; }
         if (isFalse(module.riskmgmt.isMakePermitted(
             module.datafeed.getOrderPrice(sellQuantity, buyQuantity),
-            buyQuantity,
-            module.datafeed.getReferencePrice(sellAsset, buyAsset)
+            module.datafeed.getReferencePrice(sellAsset, buyAsset),
+            buyQuantity
         ))) { LogError(1); return; }
         if (isFalse(approveSpending(sellAsset, sellQuantity))) { LogError(2); return; }
         id = exchangeAdapter.makeOrder(EXCHANGE, sellAsset, buyAsset, sellQuantity, buyQuantity);
@@ -570,8 +570,8 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         if (isFalse(module.riskmgmt.isTakePermitted(
             // TODO check: Buying what is being sold and selling what is being bought
             module.datafeed.getOrderPrice(order.buyQuantity, order.sellQuantity),
-            order.sellQuantity, // Quantity about to be received
-            module.datafeed.getReferencePrice(order.buyAsset, order.sellAsset)
+            module.datafeed.getReferencePrice(order.buyAsset, order.sellAsset),
+            order.sellQuantity // Quantity about to be received
         ))) { LogError(1); return; }
         if (isFalse(quantity <= order.sellQuantity)) { LogError(2); return; }
         if (isFalse(approveSpending(order.buyAsset, quantity))) { LogError(3); return; }

--- a/contracts/FundHistory.sol
+++ b/contracts/FundHistory.sol
@@ -1,82 +1,9 @@
 pragma solidity ^0.4.11;
 
-import './dependencies/ERC20.sol';
+import './FundInterface.sol';
 
-/// @title Fund Contract
+
+/// @title Fund Interface Contract
 /// @author Melonport AG <team@melonport.com>
-/// @notice Simple vault
-contract FundHistory {
-
-    // TYPES
-
-    enum RequestStatus { open, cancelled, executed }
-    enum RequestType { subscribe, redeem }
-
-    struct Request {
-        address owner;
-        RequestStatus status;
-        RequestType requestType;
-        uint numShares;
-        uint offeredOrRequestedValue;
-        uint incentive;
-        uint lastFeedUpdateId;
-        uint lastFeedUpdateTime;
-        uint timestamp;
-    }
-
-    // EVENTS
-
-    event LogRequest(
-        address owner,
-        RequestStatus status,
-        RequestType requestType,
-        uint numShares,
-        uint offeredOrRequestedValue,
-        uint incentive,
-        uint lastFeedUpdateId,
-        uint lastFeedUpdateTime,
-        uint timestamp
-    );
-
-    event LogMakeOrder(
-        address EXCHANGE,
-        address sellAsset, // Asset (as registred in Asset registrar) to be sold
-        address buyAsset, // Asset (as registred in Asset registrar) to be bought
-        uint sellQuantity, // Quantity of sellAsset to be sold
-        uint buyQuantity // Quantity of sellAsset to be bought
-    );
-
-    // FIELDS
-
-    mapping (uint => Request) public requests;
-    uint public nextRequestId;
-
-    // CONSTANT METHODS
-
-    function getLastRequestId() constant returns (uint) {
-        require(nextRequestId > 0);
-        return nextRequestId - 1;
-    }
-
-    function getRequestHistory(uint start)
-    		constant
-    		returns (
-      			address[1024] owners, uint[1024] statuses, uint[1024] requestTypes,
-            uint[1024] numShares, uint[1024] offered, uint[1024] incentive,
-      			uint[1024] lastFeedId, uint[1024] lastFeedTime, uint[1024] timestamp
-    		)
-  	{
-      	for (uint i = 0; i < 1024; i++) {
-        		if (start + i >= nextRequestId) break;
-        		owners[i] = requests[start + i].owner;
-        		statuses[i] = uint(requests[start + i].status);
-        		requestTypes[i] = uint(requests[start + i].requestType);
-        		numShares[i] = requests[start + i].numShares;
-        		offered[i] = requests[start + i].offeredOrRequestedValue;
-        		incentive[i] = requests[start + i].incentive;
-        		lastFeedId[i] = requests[start + i].lastFeedUpdateId;
-        		lastFeedTime[i] = requests[start + i].lastFeedUpdateTime;
-        		timestamp[i] = requests[start + i].timestamp;
-      	}
-  	}
-}
+/// @notice An independent entity that makes reading from the blockchain more efficient
+contract FundHistory {}

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -19,6 +19,7 @@ contract FundInterface is AssetInterface {
     event RewardsConverted(uint atTimestamp, uint numSharesConverted, uint unclaimed);
     event CalculationUpdate(uint atTimestamp, uint managementReward, uint performanceReward, uint nav, uint sharePrice, uint totalSupply);
     event OrderUpdated(uint id);
+    event LogError(uint ERROR_CODE);
 
     // CONSTANT METHODS
 

--- a/contracts/competition/Competition.sol
+++ b/contracts/competition/Competition.sol
@@ -104,8 +104,7 @@ contract Competition is DBC {
          * require hopefuls.length < maxHopefulsNumber
          */
     {
-        uint id = hopefuls.length;
-        hopefuls[id] = Hopeful({
+        hopefuls.push(Hopeful({
           fund: fund,
           manager: msg.sender,
           isCompeting: true,
@@ -114,6 +113,6 @@ contract Competition is DBC {
           depositQuantity: depositQuantity,
           payoutQuantity: 0,
           finalSharePrice: 0
-        });
+        }));
     }
 }

--- a/contracts/exchange/adapter/simpleAdapter.sol
+++ b/contracts/exchange/adapter/simpleAdapter.sol
@@ -64,7 +64,6 @@ library simpleAdapter {
         uint sellQuantity,
         uint buyQuantity
     )
-        external
         returns (uint id)
     {
         id = SimpleMarket(onExchange).offer(
@@ -82,7 +81,6 @@ library simpleAdapter {
         uint id,
         uint quantity
     )
-        external
         returns (bool success)
     {
         success = SimpleMarket(onExchange).buy(id, quantity);
@@ -94,7 +92,6 @@ library simpleAdapter {
         address onExchange,
         uint id
     )
-        external
         returns (bool success)
     {
         success = SimpleMarket(onExchange).cancel(id);

--- a/contracts/exchange/adapter/simpleAdapter.sol
+++ b/contracts/exchange/adapter/simpleAdapter.sol
@@ -15,29 +15,28 @@ library simpleAdapter {
     // EVENTS
 
     event OrderUpdated(uint id);
-    event Log(address exchange, address sender);
 
     // CONSTANT METHODS
 
-    function getLastOrderId(address onConsigned)
+    function getLastOrderId(address onExchange)
         constant
         returns (uint)
     {
-        return SimpleMarket(onConsigned).last_offer_id();
+        return SimpleMarket(onExchange).last_offer_id();
     }
-    function isActive(address onConsigned, uint id)
+    function isActive(address onExchange, uint id)
         constant
         returns (bool)
     {
-        return SimpleMarket(onConsigned).isActive(id);
+        return SimpleMarket(onExchange).isActive(id);
     }
-    function getOwner(address onConsigned, uint id)
+    function getOwner(address onExchange, uint id)
         constant
         returns (address)
     {
-        return SimpleMarket(onConsigned).getOwner(id);
+        return SimpleMarket(onExchange).getOwner(id);
     }
-    function getOrder(address onConsigned, uint id)
+    function getOrder(address onExchange, uint id)
         constant
         returns (address, address, uint, uint)
     {
@@ -46,7 +45,7 @@ library simpleAdapter {
             sellAsset,
             buyQuantity,
             buyAsset
-        ) = SimpleMarket(onConsigned).getOffer(id);
+        ) = SimpleMarket(onExchange).getOffer(id);
         return (
             address(sellAsset),
             address(buyAsset),
@@ -57,20 +56,18 @@ library simpleAdapter {
 
     // NON-CONSTANT METHODS
 
+    /// @dev Only use this in context of a delegatecall, as spending of sellAsset need to be approved first
     function makeOrder(
-        address onConsigned,
+        address onExchange,
         address sellAsset,
         address buyAsset,
         uint sellQuantity,
         uint buyQuantity
     )
-        /*external*/
+        external
         returns (uint id)
     {
-        // TODO remove if not necessary
-        Log(onConsigned, msg.sender);
-        SimpleMarket ex = SimpleMarket(onConsigned);
-        id = ex.offer(
+        id = SimpleMarket(onExchange).offer(
             sellQuantity,
             ERC20(sellAsset),
             buyQuantity,
@@ -79,26 +76,28 @@ library simpleAdapter {
         OrderUpdated(id);
     }
 
+    /// @dev Only use this in context of a delegatecall, as spending of sellAsset need to be approved first
     function takeOrder(
-        address onConsigned,
+        address onExchange,
         uint id,
         uint quantity
     )
-        /*external*/
+        external
         returns (bool success)
     {
-        success = SimpleMarket(onConsigned).buy(id, quantity);
+        success = SimpleMarket(onExchange).buy(id, quantity);
         OrderUpdated(id);
     }
 
+    /// @dev Only use this in context of a delegatecall, as spending of sellAsset need to be approved first
     function cancelOrder(
-        address onConsigned,
+        address onExchange,
         uint id
     )
-        /*external*/
+        external
         returns (bool success)
     {
-        success = SimpleMarket(onConsigned).cancel(id);
+        success = SimpleMarket(onExchange).cancel(id);
         OrderUpdated(id);
     }
 }

--- a/contracts/riskmgmt/RMLiquidityProvider.sol
+++ b/contracts/riskmgmt/RMLiquidityProvider.sol
@@ -14,8 +14,8 @@ contract RMLiquididtyProvider is RiskMgmtInterface {
 
       function isMakePermitted(
           uint orderPrice,
-          uint orderQuantity,
-          uint referencePrice
+          uint referencePrice,
+          uint orderQuantity
       )
           returns (bool)
       {
@@ -24,8 +24,8 @@ contract RMLiquididtyProvider is RiskMgmtInterface {
 
       function isTakePermitted(
           uint orderPrice,
-          uint orderQuantity,
           uint referencePrice,
+          uint orderQuantity,
           address orderOwner
       )
           returns (bool)

--- a/contracts/riskmgmt/RMMakeOrders.sol
+++ b/contracts/riskmgmt/RMMakeOrders.sol
@@ -20,8 +20,8 @@ contract RMMakeOrders is RiskMgmtInterface {
 
       function isMakePermitted(
           uint orderPrice,
-          uint orderQuantity,
-          uint referencePrice
+          uint referencePrice,
+          uint orderQuantity
       )
           returns (bool)
       {
@@ -31,8 +31,8 @@ contract RMMakeOrders is RiskMgmtInterface {
 
       function isTakePermitted(
           uint orderPrice,
-          uint orderQuantity,
-          uint referencePrice
+          uint referencePrice,
+          uint orderQuantity
       )
           returns (bool)
       {

--- a/contracts/riskmgmt/RiskMgmt.sol
+++ b/contracts/riskmgmt/RiskMgmt.sol
@@ -10,8 +10,8 @@ contract RiskMgmt is RiskMgmtInterface {
 
     function isMakePermitted(
         uint orderPrice,
-        uint orderQuantity,
-        uint referencePrice
+        uint referencePrice,
+        uint orderQuantity
     )
         returns (bool)
     {
@@ -20,8 +20,8 @@ contract RiskMgmt is RiskMgmtInterface {
 
     function isTakePermitted(
         uint orderPrice,
-        uint orderQuantity,
-        uint referencePrice
+        uint referencePrice,
+        uint orderQuantity
     )
         returns (bool)
     {

--- a/contracts/riskmgmt/RiskMgmtInterface.sol
+++ b/contracts/riskmgmt/RiskMgmtInterface.sol
@@ -15,13 +15,13 @@ contract RiskMgmtInterface {
 
     function isMakePermitted(
         uint orderPrice,
-        uint orderQuantity,
-        uint referencePrice
+        uint referencePrice,
+        uint orderQuantity
     ) returns (bool) {}
 
     function isTakePermitted(
         uint orderPrice,
-        uint orderQuantity,
-        uint referencePrice
+        uint referencePrice,
+        uint orderQuantity
     ) returns (bool) {}
 }

--- a/contracts/sphere/Sphere.sol
+++ b/contracts/sphere/Sphere.sol
@@ -20,6 +20,7 @@ contract Sphere is SphereInterface, DBC, Owned {
 
     function getDataFeed() external constant returns (address) { return DATAFEED; }
     function getExchange() external constant returns (address) { return EXCHANGE; }
+    function getExchangeAdapter() external constant returns (address) { return EXCHANGE_ADAPTER; }
 
     // NON-CONSTANT METHODS
 

--- a/contracts/sphere/SphereInterface.sol
+++ b/contracts/sphere/SphereInterface.sol
@@ -9,4 +9,5 @@ contract SphereInterface {
 
     function getDataFeed() external constant returns (address) {}
     function getExchange() external constant returns (address) {}
+    function getExchangeAdapter() external constant returns (address) {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@melonproject/protocol",
-  "version": "0.3.2-alpha.24",
+  "version": "0.3.2",
   "description": "Blockchain protocol for asset management",
   "directories": {
     "test": "test"

--- a/test/fund-trading.js
+++ b/test/fund-trading.js
@@ -69,13 +69,14 @@ contract('Fund trading', (accounts) => {
     it('makes an order with expected parameters', async () => {
       const id = await fund.getLastOrderId();
       const order = await fund.orders(id);
-      assert.equal(order[0], mlnToken.address);
-      assert.equal(order[1], ethToken.address);
-      assert.equal(order[2].toNumber(), sellAmt);
-      assert.equal(order[3].toNumber(), buyAmt);
-      assert.equal(order[5].toNumber(), 0);
+      const exchangeOrderId = await simpleAdapter.getLastOrderId(simpleMarket.address);
+      assert.equal(order[0].toNumber(), exchangeOrderId.toNumber());
+      assert.equal(order[1], mlnToken.address);
+      assert.equal(order[2], ethToken.address);
+      assert.equal(order[3].toNumber(), sellAmt);
+      assert.equal(order[4].toNumber(), buyAmt);
+      // assert.equal(order[5].toNumber(), 0); // TODO fix: Timestamp
       assert.equal(order[6].toNumber(), 0);
-      assert.equal(await simpleAdapter.getLastOrderId(simpleMarket.address), 1);
     });
   });
   describe('#takeOrder', () => {


### PR DESCRIPTION
## [0.3.2]

### Added
- Function to change descriptive information in asset registrar
- Contract draft for contribution
- FundHistory
- Interfaces
- ExchagneAdapter
- Actual implementation of SimpleMarket - OasisDex exchange
- InternalAccounting cleanup
- Natspecs comments
- Participation example uPort
- Competition contract
- LogError event in Fund
- Gross asset calculations accounts for externally held assets

### Changed
- Naming: Vault -> Fund
- Naming: subscribe -> requestSubscription in Fund
- Naming: redeem -> requestRedemption in Fund
- Mappings to arrays where sensible

### Removed
- Information struct in Fund
- FundHistory dependency
- Logger

## Fixes
- Fixed: #104
- Fixed makeOrder issue

## [0.3.1]

### Added
- Introducing ability to shut down both Version and Funds.
- Implement functionality to get reference price of datafeed
- Refactor Risk Management parameters
- Adding new Risk Management module for making and taking orders based on a reference price
- Implement Proof Of Embezzlement