### PR TITLE
Proof of embezzlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Introduce the concept of an externalAdapter, that is an exchangeAdapter that can be used in conjunction w a sphere of subset externalCustodian and any kind of centralised exchange
+- Introduce concept of basic subset of Melon fund; I.e. a coarse categorisation of the type of Melon fund - such as blockchainCustodian and externalCustodian
+- Introduce concept of existsMakeOrder, i.e. whether there already is an open order for a given asset pair
+
+
+
 ### Changed
 
+- Redesign of PoE
+- Improve precision of PoE
+- Naming consistency: numShares -> sharesQuantity; Clean up natspecs comments
+
 ### Removed
+
+- Remove concept of openOrders; max open orders
 
 ## [0.3.2] - 2017-09-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.3.2]
+## [0.3.3]
+
+### Added
+
+### Changed
+
+### Removed
+
+## [0.3.2] - 2017-09-21
 
 ### Added
 - Function to change descriptive information in asset registrar
@@ -31,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - FundHistory dependency
 - Logger
 
-## Fixes
+## Fixed
 - Fixed: #104
 - Fixed makeOrder issue
 
@@ -75,6 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `FundUpdate` -> `FundUpdated`
 
 ## [0.2.0]
+
 ### Added
 - Tokens: GNO, GNT, ICN, ANT, BAT, BNT, SNT, ETC, LTC, DOGE, AVT, XRP, SNGLS incl addresses and verified on EtherScan
 - Second way to subscribe and redeem using referenceAsset directly in Fund
@@ -86,6 +95,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - From SafeMath contract to SafeMath library
 
 ## [0.1.3] - 2017-06-13
+
 ### Added
 - Fund slice calculator
 - method getting share price in reference asset
@@ -95,6 +105,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - share creation using reference asset
 
 ## [0.1.2] - 2017-06-09
+
 ### Fixed
 - publish command
 
@@ -102,6 +113,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - no change
 
 ## [0.1.0] - 2017-06-09
+
 ### Added
 - core protocol contracts
 - build directory with compiled contracts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Introduce concept of basic subset of Melon fund; I.e. a coarse categorisation of the type of Melon fund - such as blockchainCustodian and externalCustodian
 - Introduce concept of existsMakeOrder, i.e. whether there already is an open order for a given asset pair
 
-
-
 ### Changed
 
 - Redesign of PoE

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -522,7 +522,7 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         if (isZero(id)) {
             LogError(4);
             return;
-        } // TODO: check accuracy of this
+        } // TODO: validate accuracy of this
         orders.push(Order({
             exchangeId: id,
             sellAsset: sellAsset,

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -669,7 +669,7 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         // Have less than accounted for => Proof of Embezzlment
         if (isLessThan(
             ERC20(sellAsset).balanceOf(this), // Actual quantity held in fund
-            internalAccounting.previousHoldings[sellAsset].sub(quantitySentToExchange(sellAsset)) // Intended qty sold
+            internalAccounting.previousHoldings[sellAsset].sub(quantitySentToExchange(sellAsset)) // Accounted for
         )) {
             // TODO: Allocate staked shares from this to msg.sender
             // TODO: error log
@@ -677,16 +677,12 @@ contract Fund is DBC, Owned, Shares, FundInterface {
             return true;
         }
 
-        if (isEqual(
-            ERC20(sellAsset).balanceOf(this), // Actual quantity held in fund
-            internalAccounting.previousHoldings[sellAsset].sub(quantitySentToExchange(sellAsset)) // Intended qty sold
-        ))
         // Sold less or equal than intended
         // Have more or equal than accounted for
-        uint factor = 10000;
+        uint factor = MELON_BASE_UNITS;
         uint divisor = factor;
         if (isLessThan(
-            internalAccounting.previousHoldings[sellAsset].sub(quantitySentToExchange(sellAsset)), // Intended qty sold
+            internalAccounting.previousHoldings[sellAsset].sub(quantitySentToExchange(sellAsset)), // Accounted for
             ERC20(sellAsset).balanceOf(this) // Actual quantity held in fund
         )) { // Sold less than intended
             factor = divisor

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -41,28 +41,15 @@ contract FundInterface is AssetInterface {
     function decreaseStake(uint numShares) external {}
     function toogleSubscription() external {}
     function toggleRedemption() external {}
-    function shutDown() {}
+    function shutDown() external {}
     // Participation
-    function requestSubscription(
-        uint numShares,
-        uint offeredValue,
-        uint incentiveValue
-    ) external returns(uint) {}
-    function requestRedemption(
-        uint numShares,
-        uint requestedValue,
-        uint incentiveValue
-    ) external returns (uint) {}
+    function requestSubscription(uint numShares, uint offeredValue, uint incentiveValue) external returns(uint) {}
+    function requestRedemption(uint numShares, uint requestedValue, uint incentiveValue) external returns (uint) {}
     function executeRequest(uint requestId) external {}
     function cancelRequest(uint requestId) external {}
     function redeemUsingSlice(uint numShares) external {}
     // Managing
-    function makeOrder(
-        address sellAsset,
-        address buyAsset,
-        uint sellQuantity,
-        uint buyQuantity
-    ) external returns (uint) {}
+    function makeOrder(address sellAsset, address buyAsset, uint sellQuantity, uint buyQuantity) external returns (uint) {}
     function takeOrder(uint id, uint quantity) external returns (bool) {}
     function cancelOrder(uint id) external returns (bool) {}
     function closeOpenOrders(address ofBase, address ofQuote) constant {}

--- a/contracts/exchange/adapter/externalAdapter.sol
+++ b/contracts/exchange/adapter/externalAdapter.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.4.11;
 
 import '../../dependencies/ERC20.sol';
-import '../thirdparty/SimpleMarket.sol';
 
 
 /// @title SimpleAdapter Contract
@@ -9,7 +8,7 @@ import '../thirdparty/SimpleMarket.sol';
 /// @notice An adapter between the Melon protocol and DappHubs SimpleMarket
 /// @notice The concept of this can be extended to for any fully decentralised exchanges such as OasisDex, Kyber, Bancor
 /// @notice Can be implemented as a library
-library simpleAdapter {
+library externalAdapter {
 
     // EVENTS
 
@@ -17,40 +16,33 @@ library simpleAdapter {
 
     // CONSTANT METHODS
 
+    /// @dev External, thirdparty, centralised API call needed for interface
     function getLastOrderId(address onExchange)
         constant
         returns (uint)
     {
-        return SimpleMarket(onExchange).last_offer_id();
+        throw;
     }
+    /// @dev External, thirdparty, centralised API call needed for interface
     function isActive(address onExchange, uint id)
         constant
         returns (bool)
     {
-        return SimpleMarket(onExchange).isActive(id);
+        throw;
     }
+    /// @dev External, thirdparty, centralised API call needed for interface
     function getOwner(address onExchange, uint id)
         constant
         returns (address)
     {
-        return SimpleMarket(onExchange).getOwner(id);
+        throw;
     }
+    /// @dev External, thirdparty, centralised API call needed for interface
     function getOrder(address onExchange, uint id)
         constant
         returns (address, address, uint, uint)
     {
-        var (
-            sellQuantity,
-            sellAsset,
-            buyQuantity,
-            buyAsset
-        ) = SimpleMarket(onExchange).getOffer(id);
-        return (
-            address(sellAsset),
-            address(buyAsset),
-            sellQuantity,
-            buyQuantity
-        );
+        throw;
     }
 
     // NON-CONSTANT METHODS
@@ -65,16 +57,11 @@ library simpleAdapter {
     )
         returns (uint id)
     {
-        id = SimpleMarket(onExchange).offer(
-            sellQuantity,
-            ERC20(sellAsset),
-            buyQuantity,
-            ERC20(buyAsset)
-        );
+        id = ERC20(sellAsset).transfer(onExchange, sellQuantity) ? 1 : 0; // Convert bool to uint
         OrderUpdated(id);
     }
 
-    /// @dev Only use this in context of a delegatecall, as spending of sellAsset need to be approved first
+    /// @dev For this subset of adapter no immediate settlement can be expected
     function takeOrder(
         address onExchange,
         uint id,
@@ -82,8 +69,7 @@ library simpleAdapter {
     )
         returns (bool success)
     {
-        success = SimpleMarket(onExchange).buy(id, quantity);
-        OrderUpdated(id);
+        throw; // Not allowed since no immediate settlement expectation
     }
 
     /// @dev Only use this in context of a delegatecall, as spending of sellAsset need to be approved first
@@ -93,7 +79,7 @@ library simpleAdapter {
     )
         returns (bool success)
     {
-        success = SimpleMarket(onExchange).cancel(id);
+        success = true; // Always succeeds, just needs updating of internalAccounting
         OrderUpdated(id);
     }
 }

--- a/contracts/sphere/Sphere.sol
+++ b/contracts/sphere/Sphere.sol
@@ -10,17 +10,23 @@ import '../dependencies/Owned.sol';
 /// @notice Simple and static Sphere Module.
 contract Sphere is SphereInterface, DBC, Owned {
 
+    // TYPES
+
+    enum SubSet { blockchainCustodian, externalCustodian } // Disjoint subsets of all spheres
+
     // FIELDS
 
     address public DATAFEED;
     address public EXCHANGE; // Assets can be transferred to this address
     address public EXCHANGE_ADAPTER;
+    SubSet public SUBSET; // Using decentralised exchange: Not staked; Using centralised exchange: Staked
 
     // CONSTANT METHODS
 
     function getDataFeed() external constant returns (address) { return DATAFEED; }
     function getExchange() external constant returns (address) { return EXCHANGE; }
     function getExchangeAdapter() external constant returns (address) { return EXCHANGE_ADAPTER; }
+    function ofSubSet() external constant returns (uint) { return uint(SUBSET); }
 
     // NON-CONSTANT METHODS
 

--- a/contracts/sphere/SphereInterface.sol
+++ b/contracts/sphere/SphereInterface.sol
@@ -10,4 +10,5 @@ contract SphereInterface {
     function getDataFeed() external constant returns (address) {}
     function getExchange() external constant returns (address) {}
     function getExchangeAdapter() external constant returns (address) {}
+    function ofSubSet() external constant returns (uint) {}
 }


### PR DESCRIPTION
### Added

- Introduce the concept of an externalAdapter, that is an exchangeAdapter that can be used in conjunction w a sphere of subset externalCustodian and any kind of centralised exchange
- Introduce concept of basic subset of Melon fund; I.e. a coarse categorisation of the type of Melon fund - such as blockchainCustodian and externalCustodian
- Introduce concept of existsMakeOrder, i.e. whether there already is an open order for a given asset pair

### Changed

- Redesign of PoE
- Improve precision of PoE
- Naming consistency: numShares -> sharesQuantity; Clean up natspecs comments

### Removed

- Remove concept of openOrders; max open orders