### PR TITLE
Riskmgmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - clang
 cache: yarn
 before_script:
-- testrpc -l 6990000 > testrpc.log &
+- testrpc -l 6979000 > testrpc.log &
 after_script:
 - npm run coveralls
 - cat testrpc.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Redesign of PoE
 - Improve precision of PoE
-- Naming consistency: numShares -> sharesQuantity; Clean up natspecs comments
+- Naming consistency: numShares -> shareQuantity; Clean up natspecs comments
 - Babel dependency
 - uint256 for all exponents
 - AssetRegistrar.remove post condition
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Redesign of PoE
 - Improve precision of PoE
-- Naming consistency: numShares -> sharesQuantity; Clean up natspecs comments
+- Naming consistency: numShares -> shareQuantity; Clean up natspecs comments
 
 ### Removed
 

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -336,7 +336,6 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         ))
         returns(uint id)
     {
-        Request memory request;
         MELON_CONTRACT.transferFrom(msg.sender, this, offeredValue.add(incentiveValue));
         requests.push(Request({
             owner: msg.sender,

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -140,12 +140,7 @@ contract Fund is DBC, Owned, Shares, FundInterface {
     function noOpenOrders() internal returns (bool) { return isZero(internalAccounting.numberOfMakeOrders); }
     function quantitySentToExchange(address ofAsset) constant returns (uint) { return internalAccounting.quantitySentToExchange[ofAsset]; }
     function quantityExpectedToReturn(address ofAsset) constant returns (uint) { return internalAccounting.quantityExpectedToReturn[ofAsset]; }
-    function returnError(bool requirement, string message) constant returns (bool, string) {
-        if (isFalse(requirement)) {
-            ErrorMessage(message);
-            return (true, message);
-        }
-    }
+
 
     // CONSTANT METHODS - ACCOUNTING
 
@@ -501,22 +496,6 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         Redeemed(msg.sender, now, shareQuantity);
     }
 
-    function createShares(address recipient, uint shareQuantity) internal {
-        totalSupply = totalSupply.add(shareQuantity);
-        addShares(recipient, shareQuantity);
-        Subscribed(msg.sender, now, shareQuantity);
-    }
-
-    function annihilateShares(address recipient, uint shareQuantity) internal {
-        totalSupply = totalSupply.sub(shareQuantity);
-        subShares(recipient, shareQuantity);
-        Redeemed(msg.sender, now, shareQuantity);
-    }
-
-    function addShares(address recipient, uint shareQuantity) internal { balances[recipient] = balances[recipient].add(shareQuantity); }
-
-    function subShares(address recipient, uint shareQuantity) internal { balances[recipient] = balances[recipient].sub(shareQuantity); }
-
     // NON-CONSTANT METHODS - MANAGING
 
     /// @notice These are orders that are not expected to settle immediately
@@ -787,4 +766,30 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         RewardsConverted(now, shareQuantity, unclaimedRewards);
         CalculationUpdate(now, managementReward, performanceReward, nav, sharePrice, totalSupply);
     }
+
+    // INTERNAL METHODS
+
+    function createShares(address recipient, uint shareQuantity) internal {
+        totalSupply = totalSupply.add(shareQuantity);
+        addShares(recipient, shareQuantity);
+        Subscribed(msg.sender, now, shareQuantity);
+    }
+
+    function annihilateShares(address recipient, uint shareQuantity) internal {
+        totalSupply = totalSupply.sub(shareQuantity);
+        subShares(recipient, shareQuantity);
+        Redeemed(msg.sender, now, shareQuantity);
+    }
+
+    function addShares(address recipient, uint shareQuantity) internal { balances[recipient] = balances[recipient].add(shareQuantity); }
+
+    function subShares(address recipient, uint shareQuantity) internal { balances[recipient] = balances[recipient].sub(shareQuantity); }
+
+    function returnError(bool requirement, string message) internal returns (bool, string) {
+        if (isFalse(requirement)) {
+            ErrorMessage(message);
+            return (true, message);
+        }
+    }
+
 }

--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -504,6 +504,9 @@ contract Fund is DBC, Owned, Shares, FundInterface {
         if (isFalse(module.riskmgmt.isMakePermitted(
             module.datafeed.getOrderPrice(sellQuantity, buyQuantity),
             module.datafeed.getReferencePrice(sellAsset, buyAsset),
+            sellAsset,
+            buyAsset,
+            sellQuantity,
             buyQuantity
         ))) {
             LogError(2);
@@ -566,7 +569,10 @@ contract Fund is DBC, Owned, Shares, FundInterface {
             // TODO check: Buying what is being sold and selling what is being bought
             module.datafeed.getOrderPrice(order.buyQuantity, order.sellQuantity),
             module.datafeed.getReferencePrice(order.buyAsset, order.sellAsset),
-            order.sellQuantity // Quantity about to be received
+            order.sellAsset,
+            order.buyAsset,
+            order.sellQuantity,
+            order.buyQuantity
         ))) {
               LogError(1);
               return;

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -11,8 +11,7 @@ contract FundInterface is AssetInterface {
     // EVENTS
 
     event PortfolioContent(uint holdings, uint price, uint decimals);
-    event SubscribeRequest(uint requestId, address indexed ofParticipant, uint atTimestamp, uint numShares);
-    event RedeemRequest(uint requestId, address indexed ofParticipant, uint atTimestamp, uint numShares);
+    event RequestUpdated(uint id);
     event Subscribed(address indexed ofParticipant, uint atTimestamp, uint numShares);
     event Redeemed(address indexed ofParticipant, uint atTimestamp, uint numShares);
     event SpendingApproved(address onConsigned, address ofAsset, uint amount);
@@ -20,6 +19,7 @@ contract FundInterface is AssetInterface {
     event CalculationUpdate(uint atTimestamp, uint managementReward, uint performanceReward, uint nav, uint sharePrice, uint totalSupply);
     event OrderUpdated(uint id);
     event LogError(uint ERROR_CODE);
+    event ErrorMessage(string errorMessage);
 
     // CONSTANT METHODS
 
@@ -44,8 +44,8 @@ contract FundInterface is AssetInterface {
     function toggleRedemption() external {}
     function shutDown() external {}
     // Participation
-    function requestSubscription(uint numShares, uint offeredValue, uint incentiveValue) external returns(uint) {}
-    function requestRedemption(uint numShares, uint requestedValue, uint incentiveValue) external returns (uint) {}
+    function requestSubscription(uint giveQuantity, uint shareQuantity, uint workerReward) external returns (bool, string) {}
+    function requestRedemption(uint shareQuantity, uint receiveQuantity, uint workerReward) external returns (bool, string) {}
     function executeRequest(uint requestId) external {}
     function cancelRequest(uint requestId) external {}
     function redeemUsingSlice(uint numShares) external {}

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -46,8 +46,8 @@ contract FundInterface is AssetInterface {
     // Participation
     function requestSubscription(uint giveQuantity, uint shareQuantity, uint workerReward) external returns (bool, string) {}
     function requestRedemption(uint shareQuantity, uint receiveQuantity, uint workerReward) external returns (bool, string) {}
-    function executeRequest(uint requestId) external {}
-    function cancelRequest(uint requestId) external {}
+    function executeRequest(uint requestId) external returns (bool, string) {}
+    function cancelRequest(uint requestId) external returns (bool, string) {}
     function redeemUsingSlice(uint numShares) external {}
     // Managing
     function makeOrder(address sellAsset, address buyAsset, uint sellQuantity, uint buyQuantity) external returns (uint) {}

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -12,10 +12,10 @@ contract FundInterface is AssetInterface {
 
     event PortfolioContent(uint holdings, uint price, uint decimals);
     event RequestUpdated(uint id);
-    event Subscribed(address indexed ofParticipant, uint atTimestamp, uint sharesQuantity);
-    event Redeemed(address indexed ofParticipant, uint atTimestamp, uint sharesQuantity);
+    event Subscribed(address indexed ofParticipant, uint atTimestamp, uint shareQuantity);
+    event Redeemed(address indexed ofParticipant, uint atTimestamp, uint shareQuantity);
     event SpendingApproved(address onConsigned, address ofAsset, uint amount);
-    event RewardsConverted(uint atTimestamp, uint sharesQuantityConverted, uint unclaimed);
+    event RewardsConverted(uint atTimestamp, uint shareQuantityConverted, uint unclaimed);
     event CalculationUpdate(uint atTimestamp, uint managementReward, uint performanceReward, uint nav, uint sharePrice, uint totalSupply);
     event OrderUpdated(uint id);
     event LogError(uint ERROR_CODE);
@@ -45,12 +45,12 @@ contract FundInterface is AssetInterface {
     function requestRedemption(uint shareQuantity, uint receiveQuantity, uint workerReward) external returns (bool, string) {}
     function executeRequest(uint requestId) external returns (bool, string) {}
     function cancelRequest(uint requestId) external returns (bool, string) {}
-    function redeemUsingSlice(uint sharesQuantity) external {}
+    function redeemUsingSlice(uint shareQuantity) external {}
     // Administration by Manager
     function toogleSubscription() external {}
     function toggleRedemption() external {}
-    function increaseStake(uint sharesQuantity) external {}
-    function decreaseStake(uint sharesQuantity) external {}
+    function increaseStake(uint shareQuantity) external {}
+    function decreaseStake(uint shareQuantity) external {}
     function shutDown() external {}
     // Managing by Manager
     function makeOrder(address sellAsset, address buyAsset, uint sellQuantity, uint buyQuantity) external returns (bool, string) {}

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -53,9 +53,9 @@ contract FundInterface is AssetInterface {
     function decreaseStake(uint sharesQuantity) external {}
     function shutDown() external {}
     // Managing by Manager
-    function makeOrder(address sellAsset, address buyAsset, uint sellQuantity, uint buyQuantity) external returns (uint) {}
-    function takeOrder(uint id, uint quantity) external returns (bool) {}
-    function cancelOrder(uint id) external returns (bool) {}
+    function makeOrder(address sellAsset, address buyAsset, uint sellQuantity, uint buyQuantity) external returns (bool, string) {}
+    function takeOrder(uint id, uint quantity) external returns (bool, string) {}
+    function cancelOrder(uint id) external returns (bool, string) {}
     function closeOpenOrders(address ofBase, address ofQuote) constant {}
     function proofOfEmbezzlement(address ofBase, address ofQuote) constant returns (bool) {}
     // Rewards by Manager

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -25,15 +25,18 @@ contract FundInterface is AssetInterface {
 
     // Get general information
     function getCreationTime() constant returns (uint) {}
+    function getBaseUnits() constant returns (uint) {}
     function getModules() constant returns (address ,address, address, address) {}
     function getStake() constant returns (uint) {}
     function getLastOrderId() constant returns (uint) {}
     function getLastRequestId() constant returns (uint) {}
+    // Get staking information
     function noOpenOrders() internal returns (bool) {}
     function quantitySentToExchange(address ofAsset) constant returns (uint) {}
     function quantityExpectedToReturn(address ofAsset) constant returns (uint) {}
     // Get accounting information
     function performCalculations() constant returns (uint, uint, uint, uint, uint, uint) {}
+    function calcSharePrice() constant returns (uint) {}
 
     // NON-CONSTANT METHODS
 

--- a/contracts/FundInterface.sol
+++ b/contracts/FundInterface.sol
@@ -12,10 +12,10 @@ contract FundInterface is AssetInterface {
 
     event PortfolioContent(uint holdings, uint price, uint decimals);
     event RequestUpdated(uint id);
-    event Subscribed(address indexed ofParticipant, uint atTimestamp, uint numShares);
-    event Redeemed(address indexed ofParticipant, uint atTimestamp, uint numShares);
+    event Subscribed(address indexed ofParticipant, uint atTimestamp, uint sharesQuantity);
+    event Redeemed(address indexed ofParticipant, uint atTimestamp, uint sharesQuantity);
     event SpendingApproved(address onConsigned, address ofAsset, uint amount);
-    event RewardsConverted(uint atTimestamp, uint numSharesConverted, uint unclaimed);
+    event RewardsConverted(uint atTimestamp, uint sharesQuantityConverted, uint unclaimed);
     event CalculationUpdate(uint atTimestamp, uint managementReward, uint performanceReward, uint nav, uint sharePrice, uint totalSupply);
     event OrderUpdated(uint id);
     event LogError(uint ERROR_CODE);
@@ -37,24 +37,24 @@ contract FundInterface is AssetInterface {
 
     // NON-CONSTANT METHODS
 
-    // Administration
-    function increaseStake(uint numShares) external {}
-    function decreaseStake(uint numShares) external {}
-    function toogleSubscription() external {}
-    function toggleRedemption() external {}
-    function shutDown() external {}
-    // Participation
+    // Participation by Investor
     function requestSubscription(uint giveQuantity, uint shareQuantity, uint workerReward) external returns (bool, string) {}
     function requestRedemption(uint shareQuantity, uint receiveQuantity, uint workerReward) external returns (bool, string) {}
     function executeRequest(uint requestId) external returns (bool, string) {}
     function cancelRequest(uint requestId) external returns (bool, string) {}
-    function redeemUsingSlice(uint numShares) external {}
-    // Managing
+    function redeemUsingSlice(uint sharesQuantity) external {}
+    // Administration by Manager
+    function toogleSubscription() external {}
+    function toggleRedemption() external {}
+    function increaseStake(uint sharesQuantity) external {}
+    function decreaseStake(uint sharesQuantity) external {}
+    function shutDown() external {}
+    // Managing by Manager
     function makeOrder(address sellAsset, address buyAsset, uint sellQuantity, uint buyQuantity) external returns (uint) {}
     function takeOrder(uint id, uint quantity) external returns (bool) {}
     function cancelOrder(uint id) external returns (bool) {}
     function closeOpenOrders(address ofBase, address ofQuote) constant {}
     function proofOfEmbezzlement(address ofBase, address ofQuote) constant returns (bool) {}
-    // Rewards
+    // Rewards by Manager
     function convertUnclaimedRewards() external {}
 }

--- a/contracts/exchange/ExchangeInterface.sol
+++ b/contracts/exchange/ExchangeInterface.sol
@@ -17,20 +17,21 @@ contract ExchangeInterface {
 
     // CONSTANT METHODS
 
-    function getLastOrderId(address onConsigned) constant returns (uint) {}
-    function isActive(address onConsigned, uint id) constant returns (bool) {}
-    function getOwner(address onConsigned, uint id) constant returns (address) {}
-    function getOrder(address onConsigned, uint id) constant returns (address, address, uint, uint) {}
+    function getLastOrderId(address onExchange) constant returns (uint) {}
+    function isActive(address onExchange, uint id) constant returns (bool) {}
+    function getOwner(address onExchange, uint id) constant returns (address) {}
+    function getOrder(address onExchange, uint id) constant returns (address, address, uint, uint) {}
+    function getTimestamp(address onExchange, uint id) constant returns (uint) {}
 
     // NON-CONSTANT METHODS
 
     function makeOrder(
-        address onConsigned,
+        address onExchange,
         address sellAsset,
         address buyAsset,
         uint sellQuantity,
         uint buyQuantity
     ) external returns (uint) {}
-    function takeOrder(address onConsigned, uint id, uint quantity) external returns (bool) {}
-    function cancelOrder(address onConsigned, uint id) external returns (bool) {}
+    function takeOrder(address onExchange, uint id, uint quantity) external returns (bool) {}
+    function cancelOrder(address onExchange, uint id) external returns (bool) {}
 }

--- a/contracts/exchange/adapter/externalAdapter.sol
+++ b/contracts/exchange/adapter/externalAdapter.sol
@@ -44,6 +44,12 @@ library externalAdapter {
     {
         throw;
     }
+    function getTimestamp(address onExchange, uint id)
+        constant
+        returns (uint)
+    {
+        throw;
+    }
 
     // NON-CONSTANT METHODS
 

--- a/contracts/exchange/adapter/simpleAdapter.sol
+++ b/contracts/exchange/adapter/simpleAdapter.sol
@@ -52,6 +52,13 @@ library simpleAdapter {
             buyQuantity
         );
     }
+    function getTimestamp(address onExchange, uint id)
+        constant
+        returns (uint)
+    {
+        var (, , , , , , timestamp) = SimpleMarket(onExchange).offers(id);
+        return timestamp;
+    }
 
     // NON-CONSTANT METHODS
 

--- a/contracts/governance/Version.sol
+++ b/contracts/governance/Version.sol
@@ -4,11 +4,12 @@ import '../Fund.sol';
 import '../FundInterface.sol';
 import '../dependencies/DBC.sol';
 import '../dependencies/Owned.sol';
+import './VersionInterface.sol';
 
 /// @title Version Contract
 /// @author Melonport AG <team@melonport.com>
 /// @notice Simple and static Management Fee.
-contract Version is DBC, Owned {
+contract Version is DBC, Owned, VersionInterface {
 
     // TYPES
 
@@ -124,5 +125,4 @@ contract Version is DBC, Owned {
         delete funds[id];
         FundUpdated(id);
     }
-
 }

--- a/contracts/governance/VersionInterface.sol
+++ b/contracts/governance/VersionInterface.sol
@@ -3,4 +3,32 @@ pragma solidity ^0.4.11;
 /// @title Version Contract
 /// @author Melonport AG <team@melonport.com>
 /// @notice This is to be considered as an interface on how to access the underlying Version Contract
-contract VersionInterface {}
+contract VersionInterface {
+
+      // EVENTS
+
+      event FundAdded(address fundAddr, uint id, string name, uint256 atTime);
+      event FundUpdated(uint id);
+
+      // CONSTANT METHODS
+
+      function getFund(uint id) constant returns (address) {}
+      function fundForManager(address ofManager) constant returns (address) {}
+      function getMelonAsset() constant returns (address) {}
+      function getNextFundId() constant returns (uint) {}
+      function getLastFundId() constant returns (uint) {}
+
+      // NON-CONSTANT METHODS
+
+      function setupFund(
+          string withName,
+          string withSymbol,
+          uint withDecimals,
+          uint ofManagementRewardRate,
+          uint ofPerformanceRewardRate,
+          address ofParticipation,
+          address ofRiskMgmt,
+          address ofSphere
+      ) {}
+      function shutDownFund(uint id) {}
+}

--- a/contracts/participation/Participation.sol
+++ b/contracts/participation/Participation.sol
@@ -27,12 +27,12 @@ contract Participation is ParticipationInterface, DBC, Owned {
 
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to invest in a Melon fund
-    /// @param numShares Quantity of shares times 10 ** 18 requested to be received
-    /// @param offeredValue Quantity of Melon token times 10 ** 18 offered to receive numShares
+    /// @param shareQuantity Quantity of shares times 10 ** 18 requested to be received
+    /// @param offeredValue Quantity of Melon token times 10 ** 18 offered to receive shareQuantity
     /// @return Whether identity is eligible to invest in a Melon fund.
     function isSubscriptionPermitted(
         address ofParticipant,
-        uint256 numShares,
+        uint256 shareQuantity,
         uint256 offeredValue
     )
         returns (bool isEligible)
@@ -40,14 +40,18 @@ contract Participation is ParticipationInterface, DBC, Owned {
         isEligible = identities[ofParticipant].hasUportId; // Eligible iff has uPort identity
     }
 
+    function isSubscriptionPermitted2(
+        Request request
+    ) returns (bool isEligible) {}
+
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to redeem from a Melon fund
-    /// @param numShares Quantity of shares times 10 ** 18 offered to redeem
-    /// @param requestedValue Quantity of Melon token times 10 ** 18 requested to receive for numShares
+    /// @param shareQuantity Quantity of shares times 10 ** 18 offered to redeem
+    /// @param requestedValue Quantity of Melon token times 10 ** 18 requested to receive for shareQuantity
     /// @return Whether identity is eligible to redeem from a Melon fund.
     function isRedemptionPermitted(
         address ofParticipant,
-        uint256 numShares,
+        uint256 shareQuantity,
         uint256 requestedValue
     )
         returns (bool isEligible)

--- a/contracts/participation/Participation.sol
+++ b/contracts/participation/Participation.sol
@@ -40,10 +40,6 @@ contract Participation is ParticipationInterface, DBC, Owned {
         isEligible = identities[ofParticipant].hasUportId; // Eligible iff has uPort identity
     }
 
-    function isSubscriptionPermitted2(
-        Request request
-    ) returns (bool isEligible) {}
-
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to redeem from a Melon fund
     /// @param shareQuantity Quantity of shares times 10 ** 18 offered to redeem

--- a/contracts/participation/Participation.sol
+++ b/contracts/participation/Participation.sol
@@ -27,13 +27,13 @@ contract Participation is ParticipationInterface, DBC, Owned {
 
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to invest in a Melon fund
+    /// @param giveQuantity Quantity of Melon token times 10 ** 18 offered to receive shareQuantity
     /// @param shareQuantity Quantity of shares times 10 ** 18 requested to be received
-    /// @param offeredValue Quantity of Melon token times 10 ** 18 offered to receive shareQuantity
     /// @return Whether identity is eligible to invest in a Melon fund.
     function isSubscriptionPermitted(
         address ofParticipant,
-        uint256 shareQuantity,
-        uint256 offeredValue
+        uint256 giveQuantity,
+        uint256 shareQuantity
     )
         returns (bool isEligible)
     {
@@ -43,12 +43,12 @@ contract Participation is ParticipationInterface, DBC, Owned {
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to redeem from a Melon fund
     /// @param shareQuantity Quantity of shares times 10 ** 18 offered to redeem
-    /// @param requestedValue Quantity of Melon token times 10 ** 18 requested to receive for shareQuantity
+    /// @param receiveQuantity Quantity of Melon token times 10 ** 18 requested to receive for shareQuantity
     /// @return Whether identity is eligible to redeem from a Melon fund.
     function isRedemptionPermitted(
         address ofParticipant,
         uint256 shareQuantity,
-        uint256 requestedValue
+        uint256 receiveQuantity
     )
         returns (bool isEligible)
     {

--- a/contracts/participation/ParticipationInterface.sol
+++ b/contracts/participation/ParticipationInterface.sol
@@ -9,23 +9,23 @@ contract ParticipationInterface {
 
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to invest in a Melon fund
-    /// @param numShares Quantity of shares times 10 ** 18 requested to be received
-    /// @param offeredValue Quantity of Melon token times 10 ** 18 offered to receive numShares
+    /// @param shareQuantity Quantity of shares times 10 ** 18 requested to be received
+    /// @param offeredValue Quantity of Melon token times 10 ** 18 offered to receive shareQuantity
     /// @return Whether identity is eligible to invest in a Melon fund.
     function isSubscriptionPermitted(
         address ofParticipant,
-        uint256 numShares,
+        uint256 shareQuantity,
         uint256 offeredValue
     ) returns (bool isEligible) {}
 
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to redeem from a Melon fund
-    /// @param numShares Quantity of shares times 10 ** 18 offered to redeem
-    /// @param requestedValue Quantity of Melon token times 10 ** 18 requested to receive for numShares
+    /// @param shareQuantity Quantity of shares times 10 ** 18 offered to redeem
+    /// @param requestedValue Quantity of Melon token times 10 ** 18 requested to receive for shareQuantity
     /// @return Whether identity is eligible to redeem from a Melon fund.
     function isRedemptionPermitted(
         address ofParticipant,
-        uint256 numShares,
+        uint256 shareQuantity,
         uint256 requestedValue
     ) returns (bool isEligible) {}
 }

--- a/contracts/participation/ParticipationInterface.sol
+++ b/contracts/participation/ParticipationInterface.sol
@@ -9,23 +9,23 @@ contract ParticipationInterface {
 
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to invest in a Melon fund
+    /// @param giveQuantity Quantity of Melon token times 10 ** 18 offered to receive shareQuantity
     /// @param shareQuantity Quantity of shares times 10 ** 18 requested to be received
-    /// @param offeredValue Quantity of Melon token times 10 ** 18 offered to receive shareQuantity
     /// @return Whether identity is eligible to invest in a Melon fund.
     function isSubscriptionPermitted(
         address ofParticipant,
-        uint256 shareQuantity,
-        uint256 offeredValue
+        uint256 giveQuantity,
+        uint256 shareQuantity
     ) returns (bool isEligible) {}
 
     /// @notice Required for Melon protocol interaction.
     /// @param ofParticipant Address requesting to redeem from a Melon fund
     /// @param shareQuantity Quantity of shares times 10 ** 18 offered to redeem
-    /// @param requestedValue Quantity of Melon token times 10 ** 18 requested to receive for shareQuantity
+    /// @param receiveQuantity Quantity of Melon token times 10 ** 18 requested to receive for shareQuantity
     /// @return Whether identity is eligible to redeem from a Melon fund.
     function isRedemptionPermitted(
         address ofParticipant,
         uint256 shareQuantity,
-        uint256 requestedValue
+        uint256 receiveQuantity
     ) returns (bool isEligible) {}
 }

--- a/contracts/participation/ParticipationOpen.sol
+++ b/contracts/participation/ParticipationOpen.sol
@@ -11,20 +11,30 @@ contract ParticipationOpen is ParticipationInterface, DBC, Owned {
 
     // CONSTANT METHODS
 
+    /// @notice Required for Melon protocol interaction.
+    /// @param ofParticipant Address requesting to invest in a Melon fund
+    /// @param giveQuantity Quantity of Melon token times 10 ** 18 offered to receive shareQuantity
+    /// @param shareQuantity Quantity of shares times 10 ** 18 requested to be received
+    /// @return Whether identity is eligible to invest in a Melon fund.
     function isSubscriptionPermitted(
         address ofParticipant,
-        uint256 shareQuantity,
-        uint256 offeredValue
+        uint256 giveQuantity,
+        uint256 shareQuantity
     )
         returns (bool isEligible)
     {
         isEligible = true;
     }
 
+    /// @notice Required for Melon protocol interaction.
+    /// @param ofParticipant Address requesting to redeem from a Melon fund
+    /// @param shareQuantity Quantity of shares times 10 ** 18 offered to redeem
+    /// @param receiveQuantity Quantity of Melon token times 10 ** 18 requested to receive for shareQuantity
+    /// @return Whether identity is eligible to redeem from a Melon fund.
     function isRedemptionPermitted(
         address ofParticipant,
         uint256 shareQuantity,
-        uint256 requestedValue
+        uint256 receiveQuantity
     )
         returns (bool isEligible)
     {

--- a/contracts/participation/ParticipationOpen.sol
+++ b/contracts/participation/ParticipationOpen.sol
@@ -13,7 +13,7 @@ contract ParticipationOpen is ParticipationInterface, DBC, Owned {
 
     function isSubscriptionPermitted(
         address ofParticipant,
-        uint256 numShares,
+        uint256 shareQuantity,
         uint256 offeredValue
     )
         returns (bool isEligible)
@@ -23,7 +23,7 @@ contract ParticipationOpen is ParticipationInterface, DBC, Owned {
 
     function isRedemptionPermitted(
         address ofParticipant,
-        uint256 numShares,
+        uint256 shareQuantity,
         uint256 requestedValue
     )
         returns (bool isEligible)

--- a/contracts/riskmgmt/RMLiquidityProvider.sol
+++ b/contracts/riskmgmt/RMLiquidityProvider.sol
@@ -15,7 +15,10 @@ contract RMLiquididtyProvider is RiskMgmtInterface {
       function isMakePermitted(
           uint orderPrice,
           uint referencePrice,
-          uint orderQuantity
+          address sellAsset,
+          address buyAsset,
+          uint sellQuantity,
+          uint buyQuantity
       )
           returns (bool)
       {
@@ -26,6 +29,10 @@ contract RMLiquididtyProvider is RiskMgmtInterface {
           uint orderPrice,
           uint referencePrice,
           uint orderQuantity,
+          address sellAsset,
+          address buyAsset,
+          uint sellQuantity,
+          uint buyQuantity,
           address orderOwner
       )
           returns (bool)

--- a/contracts/riskmgmt/RMMakeOrders.sol
+++ b/contracts/riskmgmt/RMMakeOrders.sol
@@ -21,7 +21,10 @@ contract RMMakeOrders is RiskMgmtInterface {
       function isMakePermitted(
           uint orderPrice,
           uint referencePrice,
-          uint orderQuantity
+          address sellAsset,
+          address buyAsset,
+          uint sellQuantity,
+          uint buyQuantity
       )
           returns (bool)
       {
@@ -32,7 +35,10 @@ contract RMMakeOrders is RiskMgmtInterface {
       function isTakePermitted(
           uint orderPrice,
           uint referencePrice,
-          uint orderQuantity
+          address sellAsset,
+          address buyAsset,
+          uint sellQuantity,
+          uint buyQuantity
       )
           returns (bool)
       {

--- a/contracts/riskmgmt/RiskMgmt.sol
+++ b/contracts/riskmgmt/RiskMgmt.sol
@@ -11,7 +11,10 @@ contract RiskMgmt is RiskMgmtInterface {
     function isMakePermitted(
         uint orderPrice,
         uint referencePrice,
-        uint orderQuantity
+        address sellAsset,
+        address buyAsset,
+        uint sellQuantity,
+        uint buyQuantity
     )
         returns (bool)
     {
@@ -21,7 +24,10 @@ contract RiskMgmt is RiskMgmtInterface {
     function isTakePermitted(
         uint orderPrice,
         uint referencePrice,
-        uint orderQuantity
+        address sellAsset,
+        address buyAsset,
+        uint sellQuantity,
+        uint buyQuantity
     )
         returns (bool)
     {

--- a/contracts/riskmgmt/RiskMgmtInterface.sol
+++ b/contracts/riskmgmt/RiskMgmtInterface.sol
@@ -16,12 +16,18 @@ contract RiskMgmtInterface {
     function isMakePermitted(
         uint orderPrice,
         uint referencePrice,
-        uint orderQuantity
+        address sellAsset,
+        address buyAsset,
+        uint sellQuantity,
+        uint buyQuantity
     ) returns (bool) {}
 
     function isTakePermitted(
         uint orderPrice,
         uint referencePrice,
-        uint orderQuantity
+        address sellAsset,
+        address buyAsset,
+        uint sellQuantity,
+        uint buyQuantity
     ) returns (bool) {}
 }

--- a/test/fund-shares.js
+++ b/test/fund-shares.js
@@ -98,7 +98,7 @@ contract('Fund shares', (accounts) => {
       await fund.requestSubscription(numShares, offeredValue, incentive, { from: investor });
     });
     it('logs request event', (done) => {
-      const reqEvent = fund.SubscribeRequest();
+      const reqEvent = fund.RequestUpdated();
       reqEvent.get((err, events) => {
         if (err) throw err;
         assert.equal(events.length, 1);

--- a/test/fund-trading.js
+++ b/test/fund-trading.js
@@ -71,12 +71,12 @@ contract('Fund trading', (accounts) => {
       const order = await fund.orders(id);
       const exchangeOrderId = await simpleAdapter.getLastOrderId(simpleMarket.address);
       assert.equal(order[0].toNumber(), exchangeOrderId.toNumber());
-      assert.equal(order[1], mlnToken.address);
-      assert.equal(order[2], ethToken.address);
-      assert.equal(order[3].toNumber(), sellAmt);
-      assert.equal(order[4].toNumber(), buyAmt);
-      // assert.equal(order[5].toNumber(), 0); // TODO fix: Timestamp
-      assert.equal(order[6].toNumber(), 0);
+      assert.equal(order[3], mlnToken.address);
+      assert.equal(order[4], ethToken.address);
+      assert.equal(order[5].toNumber(), sellAmt);
+      assert.equal(order[6].toNumber(), buyAmt);
+      // assert.equal(order[7].toNumber(), 0); // TODO fix: Timestamp
+      assert.equal(order[8].toNumber(), 0);
     });
   });
   describe('#takeOrder', () => {


### PR DESCRIPTION
### Added
- Init VersionInterface; Simplified executeRequest 
- Add calcSharePrice, getBaseUnits to fund interface

### Changed 
- Reorder Order struct 
- Rename numShares -> shareQuantity 
- Change RiskMgmt interface to include order quadruple of buy/sell asset/quantity
- Refactoring dispatching of requests 
- Refactor executeRequest and cancelRequst 
- Request functions update natspec comments 

### Fixed
- Fix #125 
- Fix #161 
- Fix #148 