### PR TITLE
mangertofund w only one fund

### DIFF
--- a/src/version/Version.sol
+++ b/src/version/Version.sol
@@ -102,7 +102,7 @@ contract Version is DBC, Owned {
     )
         pre_cond(termsAndConditionsAreSigned(v, r, s))
         pre_cond(notShutDown())
-        pre_cond(managerToFunds[msg.sender] != 0) // Add limitation for simpler migration process of shutting down and setting up fund
+        pre_cond(managerToFunds[msg.sender] == 0) // Add limitation for simpler migration process of shutting down and setting up fund
     {
         require(!fundNameExists[withName]);
         address fund = new Fund(

--- a/src/version/Version.sol
+++ b/src/version/Version.sol
@@ -102,6 +102,7 @@ contract Version is DBC, Owned {
     )
         pre_cond(termsAndConditionsAreSigned(v, r, s))
         pre_cond(notShutDown())
+        pre_cond(managerToFunds[msg.sender] != 0) // Add limitation for simpler migration process of shutting down and setting up fund
     {
         require(!fundNameExists[withName]);
         address fund = new Fund(

--- a/src/version/Version.sol
+++ b/src/version/Version.sol
@@ -10,13 +10,6 @@ import './VersionInterface.sol';
 /// @author Melonport AG <team@melonport.com>
 /// @notice Simple and static Management Fee.
 contract Version is DBC, Owned {
-
-    // TYPES
-
-    struct FundAddress { // Describes all modular parts, standardised through an interface
-        address fund; // Provides all external data
-    }
-
     // FIELDS
 
     // Constant fields
@@ -27,7 +20,7 @@ contract Version is DBC, Owned {
     address public GOVERNANCE; // Address of Melon protocol governance contract
     // Methods fields
     bool public isShutDown; // Governance feature, if yes than setupFund gets blocked and shutDownFund gets opened
-    mapping (address => FundAddress[]) public managerToFunds; // Links manager address to fund addresses created using this version
+    mapping (address => address) public managerToFunds; // Links manager address to fund address created using this version
     address[] public listOfFunds; // A complete list of fund addresses created using this version
     mapping (string => bool) fundNameExists; // Links fund names to boolean based on existence
     // EVENTS
@@ -125,7 +118,7 @@ contract Version is DBC, Owned {
         );
         listOfFunds.push(fund);
         fundNameExists[withName] = true;
-        managerToFunds[msg.sender].push(FundAddress(fund));
+        managerToFunds[msg.sender] = fund;
         FundUpdated(getLastFundId());
     }
 


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

- Add limitation of one fund per ethereum addr. For simpler `migration` process of shutting down and creating fund

### Deprecated

### Removed

### Fixed

### Security
