### PR TITLE
Get deployment in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "@melonproject/token-math": "^0.0.18",
+    "@melonproject/token-math": "0.0.18",
     "babel-runtime": "^6.26.0",
     "camel-case": "^3.0.0",
     "commander": "^2.19.0",

--- a/src/utils/deploySystem.ts
+++ b/src/utils/deploySystem.ts
@@ -24,6 +24,8 @@ import { deployPolicyManagerFactory } from '~/contracts/fund/policies';
 import { deployFundFactory } from '~/contracts/factory';
 import { deployMockVersion, setFundFactory } from '~/contracts/version';
 
+export const sessionDeployments = {};
+
 const debug = require('./getDebug').default(__filename);
 
 /**
@@ -102,7 +104,13 @@ export const deploySystem = async () => {
     version: versionAddress,
   };
 
-  debug('Deployed:', addresses);
+  const track = environment.track;
+  const network = await environment.eth.net.getId();
+  const deploymentId = `${network}:${track}`;
+
+  debug('Deployed:', deploymentId, addresses);
+
+  sessionDeployments[deploymentId] = addresses;
 
   return addresses;
 };

--- a/src/utils/solidity/getDeployment.test.ts
+++ b/src/utils/solidity/getDeployment.test.ts
@@ -1,10 +1,23 @@
 import { initTestEnvironment } from '../environment';
 import { getDeployment } from './getDeployment';
+import { deploySystem } from '../deploySystem';
 
 beforeAll(async () => {
   await initTestEnvironment();
 });
 
 test('Happy path', async () => {
-  await getDeployment();
+  await deploySystem();
+  const deployment = await getDeployment();
+
+  expect(Object.keys(deployment)).toEqual(
+    expect.arrayContaining([
+      'exchangeConfigs',
+      'fundFactory',
+      'policies',
+      'priceSource',
+      'tokens',
+      'version',
+    ]),
+  );
 });

--- a/src/utils/solidity/getDeployment.ts
+++ b/src/utils/solidity/getDeployment.ts
@@ -1,5 +1,4 @@
 import { getGlobalEnvironment } from '../environment';
-import { sessionDeployments } from '../deploySystem';
 
 const ensureDeployments = () => {
   try {
@@ -14,6 +13,8 @@ const ensureDeployments = () => {
 
 const doGetDeployment = (track, network) => {
   const deploymentId = `${network}:${track}`;
+
+  const { sessionDeployments } = require('../deploySystem');
 
   const deployment =
     sessionDeployments[deploymentId] || ensureDeployments()[deploymentId];

--- a/src/utils/solidity/getDeployment.ts
+++ b/src/utils/solidity/getDeployment.ts
@@ -1,4 +1,5 @@
 import { getGlobalEnvironment } from '../environment';
+import { sessionDeployments } from '../deploySystem';
 
 const ensureDeployments = () => {
   try {
@@ -11,14 +12,16 @@ const ensureDeployments = () => {
   }
 };
 
-const doGetDeployment = (deployments, track, network) => {
+const doGetDeployment = (track, network) => {
   const deploymentId = `${network}:${track}`;
-  const deployment = deployments[deploymentId];
+
+  const deployment =
+    sessionDeployments[deploymentId] || ensureDeployments()[deploymentId];
 
   if (!deployment) {
     throw new Error(
       // tslint:disable-next-line:max-line-length
-      `No deployment found with id ${deploymentId}. (chainId:track). Did you run 'yarn deploy'?`,
+      `No deployment found with id ${deploymentId}. (chainId:track)`,
     );
   }
 
@@ -26,16 +29,14 @@ const doGetDeployment = (deployments, track, network) => {
 };
 
 const getDeployment = async (environment = getGlobalEnvironment()) => {
-  const deployments = ensureDeployments();
   const track = environment.track;
   const network = await environment.eth.net.getId();
-  return doGetDeployment(deployments, track, network);
+  return doGetDeployment(track, network);
 };
 
 const getDeploymentSync = (network, environment = getGlobalEnvironment()) => {
-  const deployments = ensureDeployments();
   const track = environment.track;
-  return doGetDeployment(deployments, track, network);
+  return doGetDeployment(track, network);
 };
 
 export { getDeployment, getDeploymentSync };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "paths": {
       "~/*": ["src/*"]
     },
-    "noUnusedLocals": true
+    "noUnusedLocals": false
   },
   "files": ["typings.d.ts"],
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,9 +860,10 @@
   dependencies:
     events "^3.0.0"
 
-"@melonproject/token-math@^0.0.18":
+"@melonproject/token-math@0.0.18":
   version "0.0.18"
   resolved "https://registry.yarnpkg.com/@melonproject/token-math/-/token-math-0.0.18.tgz#dc1276908531956999f30472905a8f50451b6dbd"
+  integrity sha512-zOH1u6xYEu/OY9sS6dgcY6O3HIXwKyx8ND8i4MQrHCat0g1QMP8QjMIqnMMrGPFs7NsH+N7aisGbxntxWNLvow==
   dependencies:
     bn.js "^4.11.8"
     web3-utils "^1.0.0-beta.36"


### PR DESCRIPTION
Jest-tests deploy their own instance of the contracts to the test chain and don't write it to `out/deployments.json`. This is by intention: Test runs should not interfere with each other and also a consuming application (GraphQL server) should be affected by internal tests.

That said, sometimes it is needed to query the addresses of the current deployment. So now, if there is a deployment in the session, the current function call returns this instead of the one in `out/deployments.json`:

```ts
import { getDeployment } from '~/utils/solidity';
const deployment = await getDeployment();
```

Please note that generally it is better practice to get the addresses through the hub or version than through the deployment.