### PR TITLE
associated-fund

### DIFF
--- a/src/contracts/factory/calls/managersToHubs.ts
+++ b/src/contracts/factory/calls/managersToHubs.ts
@@ -18,7 +18,7 @@ export const managersToHubs = async (
     .managersToHubs(managerAddress.toString())
     .call();
   if (!isAddress(hubAddress) || isEmptyAddress(hubAddress)) {
-    throw new Error(`No hub for manager ${managerAddress}`);
+    return null;
   }
   return hubAddress;
 };


### PR DESCRIPTION
Return null instead of an error when no fund was found