### PR TITLE
Fix naming

### DIFF
--- a/src/contracts/dependencies/token/MaliciousToken.sol
+++ b/src/contracts/dependencies/token/MaliciousToken.sol
@@ -10,7 +10,7 @@ contract MaliciousToken is PreminedToken {
         public
         PreminedToken(_symbol, _decimals, _name)
     {}
-    
+
     function startReverting() public {
         isReverting = true;
     }

--- a/src/contracts/factory/FundFactory.sol
+++ b/src/contracts/factory/FundFactory.sol
@@ -228,7 +228,11 @@ contract FundFactory is AmguConsumer, Factory {
         hub.setRouting();
         hub.setPermissions();
         funds.push(hub);
-        Registry(registry).registerFund(address(hub));
+        Registry(registry).registerFund(
+            address(hub),
+            msg.sender,
+            managersToSettings[msg.sender].name
+        );
 
         emit NewFund(
             msg.sender,

--- a/src/contracts/factory/transactions/beginSetup.ts
+++ b/src/contracts/factory/transactions/beginSetup.ts
@@ -8,6 +8,7 @@ import {
 } from '~/utils/solidity/transactionFactory';
 import { managersToHubs } from '~/contracts/factory/calls/managersToHubs';
 import { Contracts } from '~/Contracts';
+import { stringToBytes32 } from '~/utils/helpers/stringToBytes32';
 import { BigInteger } from '@melonproject/token-math/bigInteger';
 
 // import ensure from '~/utils/guards/ensure';
@@ -72,7 +73,7 @@ const prepareArgs: PrepareArgsFunction<BeginSetupArgs> = async (
   const feePeriods = fees.map(f => `${f.feePeriod}`);
 
   const args = [
-    fundName,
+    stringToBytes32(fundName),
     feeAddresses,
     feeRates,
     feePeriods,

--- a/src/contracts/fund/shares/Shares.sol
+++ b/src/contracts/fund/shares/Shares.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.21;
 
-
 import "Shares.i.sol";
 import "Spoke.sol";
 import "StandardToken.sol";

--- a/src/contracts/version/Registry.sol
+++ b/src/contracts/version/Registry.sol
@@ -70,6 +70,7 @@ contract Registry is DSAuth {
 
     mapping (address => address) public fundsToVersions;
     mapping (bytes32 => bool) public versionNameExists;
+    mapping (bytes32 => address) public fundNameHashToOwner;
 
     uint public constant MAX_REGISTERED_ENTITIES = 20;
 
@@ -83,12 +84,20 @@ contract Registry is DSAuth {
 
     // PUBLIC METHODS
 
-    function registerFund(address _fund) {
+    function registerFund(address _fund, address _owner, string _name) {
         require(
             versionInformation[msg.sender].exists,
             "Only a Version can register a fund"
         );
+        bytes32 nameHash = keccak256(_name);
+        require(
+            fundNameHashToOwner[nameHash] == address(0) ||
+            fundNameHashToOwner[nameHash] == _owner,
+            "Fund name already exists"
+        );
+
         fundsToVersions[_fund] = msg.sender;
+        fundNameHashToOwner[nameHash] = _owner;
     }
 
     /// @notice Registers an Asset information entry

--- a/src/contracts/version/Registry.sol
+++ b/src/contracts/version/Registry.sol
@@ -55,7 +55,7 @@ contract Registry is DSAuth {
 
     struct Version {
         bool exists;
-        string name;
+        bytes32 name;
     }
 
     // FIELDS
@@ -69,6 +69,7 @@ contract Registry is DSAuth {
     address[] public registeredVersions;
 
     mapping (address => address) public fundsToVersions;
+    mapping (bytes32 => bool) public versionNameExists;
 
     uint public constant MAX_REGISTERED_ENTITIES = 20;
 
@@ -158,10 +159,13 @@ contract Registry is DSAuth {
     /// @param _name Name of the version
     function registerVersion(
         address _version,
-        string _name
+        bytes32 _name
     ) auth {
         require(!versionInformation[_version].exists);
+        require(!versionNameExists[_name]);
         versionInformation[_version].exists = true;
+        versionNameExists[_name] = true;
+        versionInformation[_version].name = _name;
         registeredVersions.push(_version);
         assert(versionInformation[_version].exists);
         emit VersionRegistration(_version);

--- a/src/contracts/version/transactions/registerVersion.ts
+++ b/src/contracts/version/transactions/registerVersion.ts
@@ -5,16 +5,17 @@ import {
   EnhancedExecute,
 } from '~/utils/solidity/transactionFactory';
 import { Contracts } from '~/Contracts';
+import { stringToBytes32 } from '~/utils/helpers/stringToBytes32';
 
 interface RegisterVersionArgs {
   address: Address;
-  name: String;
+  name: string;
 }
 
 const prepareArgs: PrepareArgsFunction<RegisterVersionArgs> = async (
   _,
   { address, name }: RegisterVersionArgs,
-) => [`${address}`, name];
+) => [`${address}`, stringToBytes32(name)];
 
 const registerVersion: EnhancedExecute<
   RegisterVersionArgs,

--- a/src/utils/helpers/stringToBytes.ts
+++ b/src/utils/helpers/stringToBytes.ts
@@ -1,0 +1,15 @@
+import * as Web3Utils from 'web3-utils';
+import { ensure } from '~/utils/guards/ensure';
+
+export const stringToBytes = (inputString: string, numBytes: number) => {
+  const numChars = numBytes * 2; // characters needed to encode numBytes
+  ensure(
+    inputString.length <= numChars,
+    `String too long to encode with ${numBytes} bytes`,
+  );
+  return Web3Utils.padLeft(Web3Utils.stringToHex(inputString), numChars);
+};
+
+export const stringToBytes8 = (input: string) => stringToBytes(input, 8);
+
+export const stringToBytes32 = (input: string) => stringToBytes(input, 32);

--- a/src/utils/helpers/stringToBytes32.ts
+++ b/src/utils/helpers/stringToBytes32.ts
@@ -1,13 +1,3 @@
-import * as Web3Utils from 'web3-utils';
-import { ensure } from '~/utils/guards/ensure';
-
-const stringToBytes = (inputString: string, numBytes: number) => {
-  const numChars = numBytes * 2; // characters needed to encode numBytes
-  ensure(
-    inputString.length <= numChars,
-    `String too long to encode with ${numBytes} bytes`,
-  );
-  return Web3Utils.padLeft(Web3Utils.stringToHex(inputString), numChars);
-};
+import { stringToBytes } from './stringToBytes';
 
 export const stringToBytes32 = (input: string) => stringToBytes(input, 32);

--- a/src/utils/helpers/stringToBytes32.ts
+++ b/src/utils/helpers/stringToBytes32.ts
@@ -1,0 +1,13 @@
+import * as Web3Utils from 'web3-utils';
+import { ensure } from '~/utils/guards/ensure';
+
+const stringToBytes = (inputString: string, numBytes: number) => {
+  const numChars = numBytes * 2; // characters needed to encode numBytes
+  ensure(
+    inputString.length <= numChars,
+    `String too long to encode with ${numBytes} bytes`,
+  );
+  return Web3Utils.padLeft(Web3Utils.stringToHex(inputString), numChars);
+};
+
+export const stringToBytes32 = (input: string) => stringToBytes(input, 32);

--- a/src/utils/helpers/stringToBytes8.ts
+++ b/src/utils/helpers/stringToBytes8.ts
@@ -1,0 +1,3 @@
+import { stringToBytes } from './stringToBytes';
+
+export const stringToBytes32 = (input: string) => stringToBytes(input, 8);


### PR DESCRIPTION
- version names must be unique
- if you register a fund with a name in one version, that name is yours alone to use in any version
- fund names can only contain `[a-zA-Z0-9 .-_]` (space included)