### PR TITLE
DO NOT MERGE: Fee problem isolation

### DIFF
--- a/src/contracts/dependencies/token/calls/balanceOf.test.ts
+++ b/src/contracts/dependencies/token/calls/balanceOf.test.ts
@@ -9,10 +9,10 @@ import { balanceOf } from '../calls/balanceOf';
 import { getToken } from '../calls/getToken';
 import { deployToken } from '../transactions/deploy';
 import { transfer } from '../transactions/transfer';
+import { delay } from 'rxjs/operators';
 
 describe('balanceOf', () => {
   const shared: any = {};
-  const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
   beforeAll(async () => {
     shared.env = await initTestEnvironment();

--- a/src/contracts/factory/calls/getFundDetails.ts
+++ b/src/contracts/factory/calls/getFundDetails.ts
@@ -4,11 +4,12 @@ import { Address, createPrice, createQuantity } from '@melonproject/token-math';
 import { getContract } from '~/utils/solidity/getContract';
 import { Contracts } from '~/Contracts';
 import { getTokenByAddress } from '~/utils/environment/getTokenByAddress';
+import { Environment } from '~/utils/environment/Environment';
 
 export const getFundDetails = async (
-  environment,
-  contractAddress: Address,
-  versionAddress: Address,
+  environment: Environment,
+  contractAddress: Address = environment.deployment.melonContracts.ranking,
+  versionAddress: Address = environment.deployment.melonContracts.version,
 ) => {
   const contract = getContract(
     environment,

--- a/src/contracts/fund/trading/transactions/cancelOasisDexOrder.ts
+++ b/src/contracts/fund/trading/transactions/cancelOasisDexOrder.ts
@@ -14,10 +14,12 @@ import { Exchanges, Contracts } from '~/Contracts';
 import { FunctionSignatures } from '../utils/FunctionSignatures';
 import { emptyAddress } from '~/utils/constants/emptyAddress';
 
-export type CancelOasisDexOrderResult = any;
+export interface CancelOasisDexOrderResult {
+  id: string;
+}
 
 export interface CancelOasisDexOrderArgs {
-  id?: string;
+  id: string;
   maker: Address;
   makerAsset: Address;
   takerAsset: Address;

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,3 +69,6 @@ export {
   makeOasisDexOrder,
 } from '~/contracts/fund/trading/transactions/makeOasisDexOrder';
 export { withDifferentAccount } from '~/utils/environment/withDifferentAccount';
+export {
+  cancelOasisDexOrder,
+} from '~/contracts/fund/trading/transactions/cancelOasisDexOrder';

--- a/src/tests/integration/fee.test.ts
+++ b/src/tests/integration/fee.test.ts
@@ -1,0 +1,89 @@
+import { allLogsWritten } from '../utils/testLogger';
+import { Environment } from '~/utils/environment/Environment';
+import { deployAndInitTestEnv } from '../utils/deployAndInitTestEnv';
+import { setupInvestedTestFund } from '../utils/setupInvestedTestFund';
+import { createPrice, createQuantity } from '@melonproject/token-math';
+import { getTokenBySymbol } from '~/utils/environment/getTokenBySymbol';
+import { update } from '~/contracts/prices/transactions/update';
+import { getLogCurried } from '~/utils/environment/getLogCurried';
+import { performCalculations } from '~/contracts/fund/accounting/calls/performCalculations';
+import { delay } from 'rxjs/operators';
+import { getFundDetails } from '~/contracts/factory/calls/getFundDetails';
+import { getLatestBlock } from '~/utils/evm';
+
+const getLog = getLogCurried('melon:protocol:systemTest:playground');
+
+describe('feeTests', () => {
+  const shared: {
+    env?: Environment;
+    [p: string]: any;
+  } = {};
+
+  beforeAll(async () => {
+    shared.env = await deployAndInitTestEnv();
+    shared.accounts = await shared.env.eth.getAccounts();
+    shared.routes = await setupInvestedTestFund(shared.env);
+
+    const weth = getTokenBySymbol(shared.env, 'WETH');
+    const mln = getTokenBySymbol(shared.env, 'MLN');
+
+    const mlnPrice = createPrice(
+      createQuantity(mln, '1'),
+      createQuantity(weth, '2'),
+    );
+
+    const ethPrice = createPrice(
+      createQuantity(weth, '1'),
+      createQuantity(weth, '1'),
+    );
+
+    await update(shared.env, shared.env.deployment.melonContracts.priceSource, [
+      ethPrice,
+      mlnPrice,
+    ]);
+  });
+
+  afterAll(async () => {
+    await allLogsWritten();
+  });
+
+  test('', async () => {
+    const log = getLog(shared.env);
+
+    const initialCalculations = await performCalculations(
+      shared.env,
+      shared.routes.accountingAddress,
+    );
+
+    const blockBefore = await getLatestBlock(shared.env);
+
+    await delay(5000);
+
+    const blockAfter = await getLatestBlock(shared.env);
+
+    const ranking = await getFundDetails(shared.env);
+
+    await delay(5000);
+
+    const afterCalcs = await performCalculations(
+      shared.env,
+      shared.routes.accountingAddress,
+    );
+
+    log.debug({
+      afterCalcs,
+      blockAfter,
+      blockBefore,
+      initialCalculations,
+      ranking,
+    });
+
+    expect(initialCalculations.sharePrice.quote.quantity.toString()).toEqual(
+      ranking[0].sharePrice.quote.quantity.toString(),
+    );
+
+    expect(initialCalculations.sharePrice.quote.quantity.toString()).toEqual(
+      afterCalcs.sharePrice.quote.quantity.toString(),
+    );
+  });
+});

--- a/src/tests/integration/generalWalkthrough.test.ts
+++ b/src/tests/integration/generalWalkthrough.test.ts
@@ -4,6 +4,7 @@ import {
   BigInteger,
   power,
   multiply,
+  toFixed,
 } from '@melonproject/token-math';
 
 import { Exchanges } from '~/Contracts';
@@ -43,6 +44,7 @@ import {
 } from '~/utils/environment/Environment';
 import { deployAndInitTestEnv } from '../utils/deployAndInitTestEnv';
 import { calcGav } from '~/contracts/fund/accounting/calls/calcGav';
+import { getFundDetails } from '~/contracts/factory/calls/getFundDetails';
 
 describe('generalWalkthrough', () => {
   const shared: {
@@ -178,8 +180,18 @@ describe('generalWalkthrough', () => {
       await calcGav(shared.env, routes.accountingAddress),
     );
 
-    // const redemption = await redeem(routes.participationAddress);
-    // debug('Redeemed');
+    const initialCalculations = await performCalculations(
+      shared.env,
+      routes.accountingAddress,
+    );
+
+    const ranking = await getFundDetails(shared.env);
+
+    debug({ initialCalculations, ranking });
+
+    expect(toFixed(initialCalculations.sharePrice)).toEqual(
+      toFixed(ranking[0].sharePrice),
+    );
 
     await getFundHoldings(shared.env, routes.accountingAddress);
 

--- a/src/tests/integration/generalWalkthrough.test.ts
+++ b/src/tests/integration/generalWalkthrough.test.ts
@@ -44,8 +44,6 @@ import {
 } from '~/utils/environment/Environment';
 import { deployAndInitTestEnv } from '../utils/deployAndInitTestEnv';
 import { calcGav } from '~/contracts/fund/accounting/calls/calcGav';
-import { getFundDetails } from '~/contracts/factory/calls/getFundDetails';
-import { delay } from '../utils/delay';
 
 describe('generalWalkthrough', () => {
   const shared: {
@@ -179,21 +177,6 @@ describe('generalWalkthrough', () => {
     debug(
       'Executed request',
       await calcGav(shared.env, routes.accountingAddress),
-    );
-
-    const initialCalculations = await performCalculations(
-      shared.env,
-      routes.accountingAddress,
-    );
-
-    await delay(5000);
-
-    const ranking = await getFundDetails(shared.env);
-
-    debug({ initialCalculations, ranking });
-
-    expect(initialCalculations.sharePrice.quote.quantity.toString()).toEqual(
-      ranking[0].sharePrice.quote.quantity.toString(),
     );
 
     await getFundHoldings(shared.env, routes.accountingAddress);

--- a/src/tests/integration/generalWalkthrough.test.ts
+++ b/src/tests/integration/generalWalkthrough.test.ts
@@ -45,6 +45,7 @@ import {
 import { deployAndInitTestEnv } from '../utils/deployAndInitTestEnv';
 import { calcGav } from '~/contracts/fund/accounting/calls/calcGav';
 import { getFundDetails } from '~/contracts/factory/calls/getFundDetails';
+import { delay } from '../utils/delay';
 
 describe('generalWalkthrough', () => {
   const shared: {
@@ -185,12 +186,14 @@ describe('generalWalkthrough', () => {
       routes.accountingAddress,
     );
 
+    await delay(5000);
+
     const ranking = await getFundDetails(shared.env);
 
     debug({ initialCalculations, ranking });
 
-    expect(toFixed(initialCalculations.sharePrice)).toEqual(
-      toFixed(ranking[0].sharePrice),
+    expect(initialCalculations.sharePrice.quote.quantity.toString()).toEqual(
+      ranking[0].sharePrice.quote.quantity.toString(),
     );
 
     await getFundHoldings(shared.env, routes.accountingAddress);

--- a/src/tests/utils/delay.ts
+++ b/src/tests/utils/delay.ts
@@ -1,0 +1,2 @@
+export const delay = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
During integration of fees in the front-end, @gempi found an interesting "effect". I'm not sure if it is a bug of the protocol or a bug of ganache or intended behaviour at all.

# Fee default values
We found that with fees enabled, the share price of a fund decreases automatically. It decreased very fast, so the first problem is probably the fee setup:

Currently in the tests we setup the fees like this:
```typescript
const fees = [
    {
      feeAddress: melonContracts.fees.managementFee.toLowerCase(),
      feePeriod: toBI(0),
      feeRate: appendDecimals(weth, 0.02),
    },
    {
      feeAddress: melonContracts.fees.performanceFee.toLowerCase(),
      feePeriod: toBI(DAY_IN_SECONDS * 90),
      feeRate: appendDecimals(weth, 0.2),
    },
  ];
```

It seems a bit weird to me to have a `feePeriod` of 0 for the management fee. What does this mean? Shouldn't it be something like one year or also 90 days? Should the manager be able to set this value during setup or shouldn't we provide just a sane default?

# Fee calculation on ganache.

[The test file that I wrote (`fee.test.ts`) to isolate this behaviour calculates the share price 3 times with a pause between them of 5 seconds](https://github.com/melonproject/protocol/compare/fee-problem-isolation?expand=1#diff-30aa8f3177d67c5123e20bcf056e432fR58). Now the sharePrice declines as follows:

800000000000000000
799999999594114663
799999999188229325

Interestingly, there are no new blocks between the two calls (as seen in the debug output attached). Both blocks have the same timestamp.

So the second question is: Shouldn't fee calculation only depend on the block timestamp? And if so, why do we see different results on the same block with the same timestamp but 5 seconds later?

This behaviour would also explain, why the other fee tests irrationally failed: Because if I set the pause to only 1 second, the effect is not visible.

# The problem in the frontend
Lastly, in the front-end we observed that there is a different value for ranking and for fund detail view. This is probably because both queries have different caching timeouts (@fubhy  ?)

```json
{
  "initialCalculations": {
    "gav": {
      "token": {
        "address": "0x8cc1a5B95d82f5b9a770D16fDF121aD4099795b9",
        "decimals": 18,
        "symbol": "WETH"
      },
      "quantity": "1000000000000000000"
    },
    "nav": {
      "token": {
        "address": "0x8cc1a5B95d82f5b9a770D16fDF121aD4099795b9",
        "decimals": 18,
        "symbol": "WETH"
      },
      "quantity": "799999999594114664"
    },
    "sharePrice": {
      "base": {
        "token": {
          "address": "0x48b7bD588f0D71A3b534a95Dcd180f0302C87072",
          "decimals": 18,
          "symbol": "MLNF"
        },
        "quantity": "1000000000000000000"
      },
      "quote": {
        "token": {
          "address": "0x8cc1a5B95d82f5b9a770D16fDF121aD4099795b9",
          "decimals": 18,
          "symbol": "WETH"
        },
        "quantity": "799999999594114663"
      }
    }
  },
  "ranking": [
    {
      "address": "0xB58E65da7284A2672379B9Dc24FC6C25a33Ca0d5",
      "creationTime": "2019-03-15T18:20:01.000Z",
      "name": "test-fund-6h29",
      "rank": 1,
      "sharePrice": {
        "base": {
          "token": {
            "decimals": 18,
            "symbol": "MLNF"
          },
          "quantity": "1000000000000000000"
        },
        "quote": {
          "token": {
            "address": "0x8cc1a5B95d82f5b9a770D16fDF121aD4099795b9",
            "decimals": 18,
            "symbol": "WETH"
          },
          "quantity": "799999999594114663"
        }
      }
    }
  ],
  "blockBefore": {
    "number": 4698,
    "hash": "0x9dcb089331c5c1bc90b95f16020574f6ad06fe9c7359f3d7d68d542e4ce3941d",
    "parentHash": "0x36f0fc48d6975cb21006ad245dcdbcb4ce05faba183c29181e1260d6ef14c5aa",
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0000000000000000",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000004000000000000000000000000000000000000000100000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "stateRoot": "0x35b2d46172a074f4dfaa05cb838f88269327acdb6780c9146b3566c7031f3a08",
    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "miner": "0x0000000000000000000000000000000000000000",
    "difficulty": "0",
    "totalDifficulty": "0",
    "extraData": "0x",
    "size": 1000,
    "gasLimit": 8000000,
    "gasUsed": 150292,
    "timestamp": 1552674019,
    "transactions": [
      "0xdc6b3256d94ae57599aca1c3753c23d7819760b439f07dcb9acbb70df84b167f"
    ],
    "uncles": []
  },
  "blockAfter": {
    "number": 4698,
    "hash": "0x9dcb089331c5c1bc90b95f16020574f6ad06fe9c7359f3d7d68d542e4ce3941d",
    "parentHash": "0x36f0fc48d6975cb21006ad245dcdbcb4ce05faba183c29181e1260d6ef14c5aa",
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0000000000000000",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000004000000000000000000000000000000000000000100000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "stateRoot": "0x35b2d46172a074f4dfaa05cb838f88269327acdb6780c9146b3566c7031f3a08",
    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "miner": "0x0000000000000000000000000000000000000000",
    "difficulty": "0",
    "totalDifficulty": "0",
    "extraData": "0x",
    "size": 1000,
    "gasLimit": 8000000,
    "gasUsed": 150292,
    "timestamp": 1552674019,
    "transactions": [
      "0xdc6b3256d94ae57599aca1c3753c23d7819760b439f07dcb9acbb70df84b167f"
    ],
    "uncles": []
  },
  "afterCalcs": {
    "gav": {
      "token": {
        "address": "0x8cc1a5B95d82f5b9a770D16fDF121aD4099795b9",
        "decimals": 18,
        "symbol": "WETH"
      },
      "quantity": "1000000000000000000"
    },
    "nav": {
      "token": {
        "address": "0x8cc1a5B95d82f5b9a770D16fDF121aD4099795b9",
        "decimals": 18,
        "symbol": "WETH"
      },
      "quantity": "799999999188229326"
    },
    "sharePrice": {
      "base": {
        "token": {
          "address": "0x48b7bD588f0D71A3b534a95Dcd180f0302C87072",
          "decimals": 18,
          "symbol": "MLNF"
        },
        "quantity": "1000000000000000000"
      },
      "quote": {
        "token": {
          "address": "0x8cc1a5B95d82f5b9a770D16fDF121aD4099795b9",
          "decimals": 18,
          "symbol": "WETH"
        },
        "quantity": "799999999188229325"
      }
    }
  }
}
```