### PR TITLE
Redeem

### DIFF
--- a/bin/melon.js
+++ b/bin/melon.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const program = require('commander');
 const pkg = require('../package.json');
 const {
-  getPrice,
+  createPrice,
   createQuantity,
   createToken,
 } = require('@melonproject/token-math');
@@ -238,7 +238,22 @@ program
 program
   .command('set-price <symbol> <value>')
   .description('Sets a price on the price feed.')
-  .action(async (symbol, value) => {
+  .option(
+    '-e, --endpoint <endpoint>',
+    'The JSON RPC endpoint url. By default: https://localhost:8545',
+  )
+  .option('-g, --gas <number>', 'Default number of gas units to provide')
+  .option('-p, --gas-price <number>', 'Price (in wei) of each gas unit')
+  .option(
+    '-k, --keystore <pathToKeystore>',
+    'Load the deployer account from a keystore file',
+  )
+  .option(
+    '-P, --private-key <string>',
+    'Load the deployer account from a private key',
+  )
+  .option('-T, --track <string>', 'Specify a track')
+  .action(async (symbol, value, options) => {
     console.log(`Setting the price for ${symbol} to ${value}`);
     const {
       initTestEnvironment,
@@ -247,21 +262,41 @@ program
     const {
       getQuoteToken,
     } = require('../lib/contracts/prices/calls/getQuoteToken');
-    const { getDeployment } = require('../lib/utils/solidity/getDeployment');
+
     try {
-      const environment = await initTestEnvironment();
-      const { priceSource, tokens } = await getDeployment(environment);
-      const quoteToken = await getQuoteToken(priceSource, environment);
+      const environmentWithoutDeployment = await getEnvironment({
+        endpoint:
+          options.endpoint ||
+          process.env.JSON_RPC_ENDPOINT ||
+          'http://localhost:8545',
+        gasLimit: options.gas || '8000000',
+        gasPrice: options.gasPrice || '2000000000',
+        pathToKeystore: options.keystore || undefined,
+        privateKey: options.privateKey || undefined,
+        track: options.track,
+      });
+
+      checkPeerCount(environmentWithoutDeployment);
+
+      const {
+        withDeployment,
+      } = require('../lib/utils/environment/withDeployment');
+      const environment = await withDeployment(environmentWithoutDeployment);
+
+      const { priceSource } = environment.deployment.melonContracts;
+      const { tokens } = environment.deployment.thirdPartyContracts;
+
+      const quoteToken = await getQuoteToken(environment, priceSource);
       const baseToken = tokens.find(token => {
         return token.symbol === symbol.toUpperCase();
       });
 
-      const newPrice = getPrice(
+      const newPrice = createPrice(
         createQuantity(baseToken, 1),
         createQuantity(quoteToken, value),
       );
 
-      await update(priceSource, [newPrice]);
+      await update(environment, priceSource, [newPrice]);
 
       console.log(`Successfully updated the price for ${symbol}.`);
       process.exit();
@@ -273,9 +308,7 @@ program
 
 program
   .command('update-kyber-pricefeed')
-  .description(
-    'Update kyber pricefeed',
-  )
+  .description('Update kyber pricefeed')
   .option(
     '-e, --endpoint <endpoint>',
     'The JSON RPC endpoint url. By default: https://localhost:8545',
@@ -310,7 +343,9 @@ program
 
       checkPeerCount(environmentWithoutDeployment);
 
-      const { withDeployment } = require('../lib/utils/environment/withDeployment');
+      const {
+        withDeployment,
+      } = require('../lib/utils/environment/withDeployment');
       const environment = await withDeployment(environmentWithoutDeployment);
 
       const {
@@ -319,14 +354,16 @@ program
 
       const updatePeriodically = async () => {
         try {
-          await updateKyber(environment, environment.deployment.melonContracts.priceSource);
+          await updateKyber(
+            environment,
+            environment.deployment.melonContracts.priceSource,
+          );
         } catch (err) {
           console.error(err);
         }
-      }
-        
-      setInterval(updatePeriodically, options.interval);
+      };
 
+      setInterval(updatePeriodically, options.interval);
     } catch (e) {
       console.error(e);
       process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@melonproject/protocol",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "Technology Regulated and Operated Investment Funds",
   "main": "lib/index.umd.js",
   "module": "lib/index.js",

--- a/src/contracts/fund/hub/calls/getFundToken.ts
+++ b/src/contracts/fund/hub/calls/getFundToken.ts
@@ -1,0 +1,17 @@
+import { Contracts } from '~/Contracts';
+import {
+  PostProcessCallFunction,
+  callFactoryWithoutParams,
+} from '~/utils/solidity/callFactory';
+import { getToken } from '~/contracts/dependencies/token/calls/getToken';
+
+const postProcess: PostProcessCallFunction = async (environment, result) => {
+  const token = await getToken(environment, result);
+  return token;
+};
+
+const getFundToken = callFactoryWithoutParams('shares', Contracts.Hub, {
+  postProcess,
+});
+
+export { getFundToken };

--- a/src/contracts/fund/participation/transactions/redeemQuantity.ts
+++ b/src/contracts/fund/participation/transactions/redeemQuantity.ts
@@ -11,6 +11,7 @@ import {
   QuantityInterface,
   toFixed,
   isZero,
+  createToken,
 } from '@melonproject/token-math';
 import { Contracts } from '~/Contracts';
 import { getToken } from '~/contracts/dependencies/token/calls/getToken';
@@ -18,6 +19,7 @@ import { balanceOf } from '~/contracts/dependencies/token/calls/balanceOf';
 import { getHub } from '~/contracts/fund/hub/calls/getHub';
 import { getRoutes } from '~/contracts/fund/hub/calls/getRoutes';
 import { ensureIsNotShutDown } from '~/contracts/fund/hub/guards/ensureIsNotShutDown';
+import { isEmptyAddress } from '~/utils/checks/isEmptyAddress';
 
 export interface RedeemQuantityArgs {
   sharesQuantity: QuantityInterface;
@@ -61,7 +63,9 @@ const postProcess = async (environment, receipt, _, contractAddress) => {
 
   const redemptionsPromises = redemptionAddressQuantityPairs.map(
     async ([tokenAddress, quantity]) => {
-      const token = await getToken(environment, tokenAddress);
+      const token = isEmptyAddress(tokenAddress)
+        ? createToken('EMPTY')
+        : await getToken(environment, tokenAddress);
       return createQuantity(token, quantity);
     },
   );

--- a/src/contracts/fund/participation/transactions/redeemQuantity.ts
+++ b/src/contracts/fund/participation/transactions/redeemQuantity.ts
@@ -76,7 +76,9 @@ const postProcess = async (environment, receipt, _, contractAddress) => {
 
   return {
     redeemedShares,
-    redemptions: redemptions.filter((q: QuantityInterface) => !isZero(q)),
+    redemptions: redemptions.filter(
+      (q: QuantityInterface) => !isZero(q) && q.token.symbol !== 'EMPTY',
+    ),
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,8 +134,12 @@ export { take0xOrder } from '~/contracts/fund/trading/transactions/take0xOrder';
 export { make0xOrder } from '~/contracts/fund/trading/transactions/make0xOrder';
 export {
   cancel0xOrder,
-} from './contracts/fund/trading/transactions//cancel0xOrder';
+} from './contracts/fund/trading/transactions/cancel0xOrder';
 export { getRequest } from './contracts/fund/participation/calls/getRequest';
 export {
   hasValidRequest,
 } from './contracts/fund/participation/calls/hasValidRequest';
+export { getFundToken } from './contracts/fund/hub/calls/getFundToken';
+export {
+  redeemQuantity,
+} from '~/contracts/fund/participation/transactions/redeemQuantity';

--- a/src/tests/integration/managementFee.test.ts
+++ b/src/tests/integration/managementFee.test.ts
@@ -240,12 +240,12 @@ test(`Claims fee using triggerRewardAllFees`, async () => {
   // expect(postFundCalculations.sharePrice).toEqual(
   //   preFundCalculations.sharePrice,
   // );
-  expect(new BigInteger(preFundCalculations.feesInDenominationAsset)).toEqual(
-    expectedFeeInDenominationAsset,
-  );
-  expect(new BigInteger(lastConversionCalculations.allocatedFees)).toEqual(
-    expectedFeeInDenominationAsset,
-  );
+  expect(
+    new BigInteger(preFundCalculations.feesInDenominationAsset).toString(),
+  ).toEqual(expectedFeeInDenominationAsset.toString());
+  expect(
+    new BigInteger(lastConversionCalculations.allocatedFees).toString(),
+  ).toEqual(expectedFeeInDenominationAsset.toString());
   expect(post.fund.weth).toEqual(pre.fund.weth);
   expect(post.manager.weth).toEqual(pre.manager.weth);
 });


### PR DESCRIPTION
Fix redeem functionality

Plus fixed `node bin/melon.js set-price` to update the testing price source to enable re-invest on the devchain:

```bash
node bin/melon.js set-price MLN 0.06 -P 0xd3fdff38aaf7be159fc1c12c66982fea997df08ca5b91b399e437370d3681721
```