### PR TITLE
Log the private key for system tests

### DIFF
--- a/src/utils/environment/withNewAccount.ts
+++ b/src/utils/environment/withNewAccount.ts
@@ -2,8 +2,13 @@ import { default as Web3Accounts } from 'web3-eth-accounts';
 
 import { Environment } from './Environment';
 import { withPrivateKeySigner } from './withPrivateKeySigner';
+import { getLogCurried } from './getLogCurried';
+
+const getLog = getLogCurried('melon:protocol:environment:withNewAccount');
 
 const withNewAccount = async (environment: Environment) => {
+  const log = getLog(environment);
+
   const web3Accounts = new Web3Accounts(environment.eth.currentProvider);
 
   const account = web3Accounts.create();
@@ -12,6 +17,10 @@ const withNewAccount = async (environment: Environment) => {
     environment,
     account.privateKey,
   );
+
+  if (process.env.NODE_ENV !== 'production') {
+    log.info('New account created with privateKey:', account.privateKey);
+  }
 
   return enhancedEnvironment;
 };

--- a/src/utils/solidity/transactionFactory.ts
+++ b/src/utils/solidity/transactionFactory.ts
@@ -47,6 +47,7 @@ export interface UnsignedRawTransaction {
 
 export interface MelonTransaction<Args> {
   amguInEth: QuantityInterface;
+  incentiveInEth: QuantityInterface;
   params: Args;
   rawTransaction: UnsignedRawTransaction;
   // Already signed transaction in HEX as described here:
@@ -241,6 +242,7 @@ const transactionFactory: TransactionFactory = <Args, Result>(
       const melonTransaction = {
         amguInEth,
         contract,
+        incentiveInEth,
         name,
         params,
         rawTransaction: {


### PR DESCRIPTION
If one runs system-tests on the main net, new accounts are created & funded for each test run. One might want to have the private key of these accounts to return these funds.