### PR TITLE
Hardware wallet

### DIFF
--- a/src/utils/solidity/deployContract.ts
+++ b/src/utils/solidity/deployContract.ts
@@ -20,7 +20,8 @@ interface PrepareDeployReturn {
 }
 
 interface SendDeployArgs {
-  signedTransaction: string;
+  signedTransaction?: string;
+  unsignedTransaction?: UnsignedRawTransaction;
   txIdentifier?: string;
 }
 
@@ -146,15 +147,22 @@ const prepare: PrepareDeployFunction = async (
 
 const send: SendDeployFunction = async (
   environment,
-  { txIdentifier = 'Unknown deployment', signedTransaction },
+  {
+    txIdentifier = 'Unknown deployment',
+    signedTransaction,
+    unsignedTransaction,
+  },
 ) => {
   const log = getLog(environment);
 
   try {
     let txHash;
 
-    const receipt = await environment.eth
-      .sendSignedTransaction(signedTransaction)
+    const receiptPromise = !!signedTransaction
+      ? environment.eth.sendSignedTransaction(signedTransaction)
+      : environment.eth.sendTransaction(unsignedTransaction);
+
+    const receipt = await receiptPromise
       .on('error', error => {
         throw error;
       })

--- a/src/utils/solidity/transactionFactory.ts
+++ b/src/utils/solidity/transactionFactory.ts
@@ -148,6 +148,23 @@ export const defaultPostProcess: PostProcessFunction<any, any> = async () =>
   true;
 
 /**
+ * If the TX is signed, it comes as the raw signed string
+ * (result.rawTransaction) as in:
+ * https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#id5
+ *
+ * Otherwise, we assume it is a tx-object like:
+ * https://web3js.readthedocs.io/en/1.0/web3-eth-accounts.html#id4
+ * ```
+ *  {
+ *    to: '0xF0109fC8DF283027b6285cc889F5aA624EaC1F55',
+ *    value: '1000000000',
+ *    gas: 2000000
+ *  }
+ * ```
+ */
+const isSignedTx = signedOrNotTx => typeof signedOrNotTx === 'string';
+
+/**
  * The transaction factory returns a function "execute" (You have to rename it
  * to the actual name of the transaction, for example: "transfer"). As a
  * minimum, one needs to provide the transaction name and the contract path:
@@ -297,17 +314,19 @@ const transactionFactory: TransactionFactory = <Args, Result>(
   const send: SendFunction<Args> = async (
     environment,
     contractAddress,
-    signedTransactionData,
+    signedOrNotTx,
     // prepared,
     params,
   ) => {
     const log = getLog(environment);
 
-    const receipt = await environment.eth
-      .sendSignedTransaction(signedTransactionData)
-      .then(null, error => {
-        throw new Error(`Transaction failed for ${name}: ${error.message}`);
-      });
+    const receiptPromise = isSignedTx(signedOrNotTx)
+      ? environment.eth.sendSignedTransaction(signedOrNotTx)
+      : environment.eth.sendTransaction(signedOrNotTx);
+
+    const receipt = await receiptPromise.then(null, error => {
+      throw new Error(`Transaction failed for ${name}: ${error.message}`);
+    });
 
     const events = receipt.logs.reduce((carry, txLog) => {
       const eventABI = eventSignatureABIMap[txLog.topics[0]];


### PR DESCRIPTION
Changing the transaction factory and deploy methods to support two different signing strategies:

**1 (old)**: They expect to receive a signed transaction as input. This is used by our solution with in-memory wallets (insecure). There might be other use cases.
**2 (new)**: They expect to receive the unsigned transaction as input. This gives the possibility to delegate signing/nonce-handling and so on to the JSON-RPC endpoint. In our setup this is mainly Frame.sh, but can also be used on the devchain. Theoretically also with unlocked nodes and so on.