### PR TITLE
Feature/add callonexchange orderdata array

### DIFF
--- a/deploy/scripts/deploy-melon.js
+++ b/deploy/scripts/deploy-melon.js
@@ -69,10 +69,10 @@ const main = async input => {
   await send(registry, 'registerFees', [[ managementFee.options.address, performanceFee.options.address]]);
 
   const sigs = [
-    'makeOrder(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
-    'takeOrder(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
-    'cancelOrder(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
-    'withdrawTokens(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
+    'makeOrder(address,address[6],uint256[8],bytes[4],bytes32,bytes)',
+    'takeOrder(address,address[6],uint256[8],bytes[4],bytes32,bytes)',
+    'cancelOrder(address,address[6],uint256[8],bytes[4],bytes32,bytes)',
+    'withdrawTokens(address,address[6],uint256[8],bytes[4],bytes32,bytes)',
   ].map(s => web3.utils.keccak256(s).slice(0,10));
 
   const exchanges = {};

--- a/src/contracts/exchanges/EthfinexAdapter.sol
+++ b/src/contracts/exchanges/EthfinexAdapter.sol
@@ -29,15 +29,16 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes wrappedMakerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public onlyManager notShutDown {
         ensureCanMakeOrder(orderAddresses[2]);
         Hub hub = getHub();
 
-        LibOrder.Order memory order = constructOrderStruct(orderAddresses, orderValues, wrappedMakerAssetData, takerAssetData);
+        LibOrder.Order memory order = constructOrderStruct(orderAddresses, orderValues, orderData);
+        bytes memory wrappedMakerAssetData = orderData[0];
+        bytes memory takerAssetData = orderData[1];
         address makerAsset = orderAddresses[2];
         address takerAsset = getAssetAddress(takerAssetData);
         require(
@@ -69,10 +70,10 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
             [order.makerAssetAmount, order.takerAssetAmount, uint(0)]
         );
         getTrading().addOpenMakeOrder(
-            targetExchange, 
+            targetExchange,
             makerAsset,
             takerAsset,
-            uint256(orderInfo.orderHash), 
+            uint256(orderInfo.orderHash),
             order.expirationTimeSeconds
         );
         getTrading().addZeroExOrderData(orderInfo.orderHash, order);
@@ -83,9 +84,8 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes wrappedMakerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public onlyCancelPermitted(targetExchange, orderAddresses[2]) {
         Hub hub = getHub();
@@ -109,9 +109,8 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public {
         Hub hub = getHub();
@@ -196,8 +195,7 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
     function constructOrderStruct(
         address[6] orderAddresses,
         uint[8] orderValues,
-        bytes makerAssetData,
-        bytes takerAssetData
+        bytes[4] orderData
     )
         internal
         view
@@ -214,8 +212,8 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
             takerFee: orderValues[3],
             expirationTimeSeconds: orderValues[4],
             salt: orderValues[5],
-            makerAssetData: makerAssetData,
-            takerAssetData: takerAssetData
+            makerAssetData: orderData[0],
+            takerAssetData: orderData[1]
         });
     }
 

--- a/src/contracts/exchanges/ExchangeAdapter.sol
+++ b/src/contracts/exchanges/ExchangeAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.25;
+pragma experimental ABIEncoderV2;
 
 import "../fund/accounting/Accounting.sol";
 import "../fund/hub/Hub.sol";
@@ -84,9 +85,11 @@ contract ExchangeAdapter {
     /// @param orderValues [5] Salt/nonce
     /// @param orderValues [6] Fill amount: amount of taker token to be traded
     /// @param orderValues [7] Dexy signature mode
+    /// @param orderData [0] Encoded data specific to maker asset
+    /// @param orderData [1] Encoded data specific to taker asset
+    /// @param orderData [2] Encoded data specific to maker asset fee
+    /// @param orderData [3] Encoded data specific to taker asset fee
     /// @param identifier Order identifier
-    /// @param makerAssetData Encoded data specific to makerAsset
-    /// @param takerAssetData Encoded data specific to takerAsset
     /// @param signature Signature of order maker
 
     // Responsibilities of makeOrder are:
@@ -102,9 +105,8 @@ contract ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public { revert("Unimplemented"); }
 
@@ -123,9 +125,8 @@ contract ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public { revert("Unimplemented"); }
 
@@ -137,9 +138,8 @@ contract ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public { revert("Unimplemented"); }
 

--- a/src/contracts/exchanges/KyberAdapter.sol
+++ b/src/contracts/exchanges/KyberAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.25;
+pragma experimental ABIEncoderV2;
 
 import "../dependencies/Weth.sol";
 import "../fund/trading/Trading.sol";
@@ -33,16 +34,15 @@ contract KyberAdapter is DSMath, ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public onlyManager notShutDown {
         Hub hub = getHub();
 
-        require(	
-            orderValues[1] == orderValues[6],	
-            "fillTakerQuantity must equal takerAssetQuantity"	
+        require(
+            orderValues[1] == orderValues[6],
+            "fillTakerQuantity must equal takerAssetQuantity"
         );
 
         address makerAsset = orderAddresses[2];
@@ -66,7 +66,7 @@ contract KyberAdapter is DSMath, ExchangeAdapter {
         );
 
         getAccounting().addAssetToOwnedAssets(makerAsset);
-        getAccounting().updateOwnedAssets(); 
+        getAccounting().updateOwnedAssets();
         getTrading().returnAssetToVault(makerAsset);
         getTrading().orderUpdateHook(
             targetExchange,

--- a/src/contracts/exchanges/MatchingMarketAdapter.sol
+++ b/src/contracts/exchanges/MatchingMarketAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.25;
+pragma experimental ABIEncoderV2;
 
 import "../fund/hub/Hub.sol";
 import "../fund/trading/Trading.sol";
@@ -39,9 +40,8 @@ contract MatchingMarketAdapter is DSMath, ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public onlyManager notShutDown {
         ensureCanMakeOrder(orderAddresses[2]);
@@ -97,9 +97,8 @@ contract MatchingMarketAdapter is DSMath, ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public onlyManager notShutDown {
         Hub hub = getHub();
@@ -161,9 +160,8 @@ contract MatchingMarketAdapter is DSMath, ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public onlyCancelPermitted(targetExchange, orderAddresses[2]) {
         Hub hub = getHub();

--- a/src/contracts/exchanges/MockAdapter.sol
+++ b/src/contracts/exchanges/MockAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.25;
+pragma experimental ABIEncoderV2;
 
 import "../fund/trading/Trading.sol";
 import "../fund/hub/Hub.sol";
@@ -16,9 +17,8 @@ contract MockAdapter is ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public {
         Hub hub = getHub();
@@ -42,9 +42,8 @@ contract MockAdapter is ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public {
         address makerAsset = orderAddresses[2];
@@ -67,9 +66,8 @@ contract MockAdapter is ExchangeAdapter {
         address targetExchange,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public {
         Hub hub = getHub();

--- a/src/contracts/fund/policies/TradingSignatures.sol
+++ b/src/contracts/fund/policies/TradingSignatures.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.25;
 
 contract TradingSignatures {
-    bytes4 constant public MAKE_ORDER = 0x79705be7; // makeOrderSignature
-    bytes4 constant public TAKE_ORDER = 0xe51be6e8; // takeOrderSignature
+    bytes4 constant public MAKE_ORDER = 0x3b14cd7e; // makeOrderSignature
+    bytes4 constant public TAKE_ORDER = 0xd2e65751; // takeOrderSignature
 }

--- a/src/contracts/fund/trading/Trading.i.sol
+++ b/src/contracts/fund/trading/Trading.i.sol
@@ -1,15 +1,20 @@
 pragma solidity ^0.4.25;
 
+pragma experimental ABIEncoderV2;
+
+// TODO: Restore indexed params
+
 /// @notice Mediation between a Fund and exchanges
 interface TradingInterface {
     event ExchangeMethodCall(
-        address indexed exchangeAddress,
-        string indexed methodSignature,
+        // address indexed exchangeAddress,
+        // string indexed methodSignature,
+        address exchangeAddress,
+        string methodSignature,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     );
 
@@ -18,9 +23,8 @@ interface TradingInterface {
         string methodSignature,
         address[6] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     ) public;
 

--- a/tests/integration/fund0xTrading.test.js
+++ b/tests/integration/fund0xTrading.test.js
@@ -11,7 +11,7 @@
 
 import { orderHashUtils } from '@0x/order-utils';
 import { AssetProxyId } from '@0x/types';
-import { BN, randomHex, toWei } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
@@ -190,9 +190,8 @@ describe('fund-0x-trading', () => {
           fillQuantity,
           0,
         ],
-        randomHex(32),
-        signedOrder1.makerAssetData,
-        signedOrder1.takerAssetData,
+        [signedOrder1.makerAssetData, signedOrder1.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder1.signature,
       )
       .send(managerTxOpts);
@@ -304,9 +303,8 @@ describe('fund-0x-trading', () => {
           fillQuantity,
           0,
         ],
-        randomHex(32),
-        signedOrder2.makerAssetData,
-        signedOrder2.takerAssetData,
+        [signedOrder2.makerAssetData, signedOrder2.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder2.signature,
       )
       .send(managerTxOpts);
@@ -397,9 +395,8 @@ describe('fund-0x-trading', () => {
           0,
           0,
         ],
-        randomHex(32),
-        signedOrder3.makerAssetData,
-        signedOrder3.takerAssetData,
+        [signedOrder3.makerAssetData, signedOrder3.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder3.signature,
       )
       .send(managerTxOpts);
@@ -526,9 +523,8 @@ describe('fund-0x-trading', () => {
           0,
           0,
         ],
-        randomHex(32),
-        signedOrder4.makerAssetData,
-        signedOrder4.takerAssetData,
+        [signedOrder4.makerAssetData, signedOrder4.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder4.signature,
       )
       .send(managerTxOpts);
@@ -561,9 +557,8 @@ describe('fund-0x-trading', () => {
             EMPTY_ADDRESS,
           ],
           [0, 0, 0, 0, 0, 0, 0, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
           orderHashHex,
-          '0x0',
-          '0x0',
           '0x0',
         )
         .send(managerTxOpts);

--- a/tests/integration/fundEngineTrading.test.js
+++ b/tests/integration/fundEngineTrading.test.js
@@ -108,8 +108,7 @@ describe('Happy Path', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -156,8 +155,7 @@ describe('Happy Path', () => {
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-          '0x0',
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/fundEthfinexTrading.test.js
+++ b/tests/integration/fundEthfinexTrading.test.js
@@ -12,7 +12,7 @@
 
 import { orderHashUtils } from '@0x/order-utils';
 import { AssetProxyId } from '@0x/types';
-import { BN, toWei, randomHex } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
@@ -180,9 +180,8 @@ test('Make order through the fund', async () => {
         0,
         0,
       ],
-      randomHex(32),
-      order.makerAssetData,
-      order.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     )
     .send(managerTxOpts);
@@ -287,9 +286,8 @@ test('Make order with native asset', async () => {
         0,
         0,
       ],
-      randomHex(32),
-      signedOrder.makerAssetData,
-      signedOrder.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     )
     .send(managerTxOpts);
@@ -346,9 +344,8 @@ test('Cancel the order and withdraw tokens', async () => {
         EMPTY_ADDRESS,
       ],
       [0, 0, 0, 0, 0, 0, 0, 0],
+      ['0x0', '0x0', '0x0', '0x0'],
       orderHashHex,
-      '0x0',
-      '0x0',
       '0x0',
     )
     .send(managerTxOpts);
@@ -378,8 +375,7 @@ test('Cancel the order and withdraw tokens', async () => {
         EMPTY_ADDRESS,
       ],
       [0, 0, 0, 0, 0, 0, 0, 0],
-      randomHex(32),
-      '0x0',
+      ['0x0', '0x0', '0x0', '0x0'],
       '0x0',
       '0x0',
     )

--- a/tests/integration/fundKyberTrading.test.js
+++ b/tests/integration/fundKyberTrading.test.js
@@ -8,7 +8,7 @@
  * @test Fund take order fails with too high maker quantity
  */
 
-import { BN, toWei, randomHex } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
@@ -160,8 +160,7 @@ describe('fund-kyber-trading', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -216,8 +215,7 @@ describe('fund-kyber-trading', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -275,8 +273,7 @@ describe('fund-kyber-trading', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -329,8 +326,7 @@ describe('fund-kyber-trading', () => {
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/fundKyberTrading2.test.js
+++ b/tests/integration/fundKyberTrading2.test.js
@@ -122,8 +122,7 @@ describe('Happy Path', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -173,8 +172,7 @@ describe('Happy Path', () => {
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-          '0x0',
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/fundQuoteAsset.test.js
+++ b/tests/integration/fundQuoteAsset.test.js
@@ -14,7 +14,7 @@ import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
 
 import { BNExpMul } from '~/tests/utils/BNmath';
-import { CONTRACT_NAMES } from '~/tests/utils/constants';
+import { CONTRACT_NAMES, EMPTY_ADDRESS } from '~/tests/utils/constants';
 import { stringToBytes } from '~/tests/utils/formatting';
 import getFundComponents from '~/tests/utils/getFundComponents';
 import { getFunctionSignature } from '~/tests/utils/metadata';
@@ -320,12 +320,12 @@ describe('fund-quote-asset', () => {
         0,
         makeOrderSignature,
         [
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
           dgx.options.address,
           mln.options.address,
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
         ],
         [trade1.sellQuantity, trade1.buyQuantity, 0, 0, 0, 0, 0, 0],
         ['0x0', '0x0', '0x0', '0x0'],

--- a/tests/integration/fundQuoteAsset.test.js
+++ b/tests/integration/fundQuoteAsset.test.js
@@ -7,7 +7,7 @@
  * @test A fund places a make order with a quote token that is not 18 decimals
  */
 
-import { BN, toWei, randomHex } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
 
 import { fetchContract } from '~/deploy/utils/deploy-contract';
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
@@ -328,8 +328,7 @@ describe('fund-quote-asset', () => {
           randomHex(20),
         ],
         [trade1.sellQuantity, trade1.buyQuantity, 0, 0, 0, 0, 0, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )

--- a/tests/integration/fundRiskManagement.test.js
+++ b/tests/integration/fundRiskManagement.test.js
@@ -11,7 +11,7 @@
  */
 
 import { encodeFunctionSignature } from 'web3-eth-abi';
-import { BN, hexToNumber, randomHex, toWei } from 'web3-utils';
+import { BN, hexToNumber, toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import { deploy, fetchContract } from '~/deploy/utils/deploy-contract';
@@ -282,8 +282,7 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
               EMPTY_ADDRESS,
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -315,8 +314,7 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -399,8 +397,7 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
               EMPTY_ADDRESS,
             ],
             [makerQuantity, badTakerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -428,8 +425,7 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
             EMPTY_ADDRESS,
           ],
           [makerQuantity, toleratedTakerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -515,8 +511,7 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -575,8 +570,7 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
               EMPTY_ADDRESS,
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -714,8 +708,7 @@ describe('Fund 2: Asset whitelist, max positions', () => {
               EMPTY_ADDRESS,
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -749,8 +742,7 @@ describe('Fund 2: Asset whitelist, max positions', () => {
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -824,9 +816,8 @@ describe('Fund 2: Asset whitelist, max positions', () => {
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
           orderId,
-          '0x0',
-          '0x0',
           '0x0',
         )
         .send(managerTxOpts)
@@ -863,8 +854,7 @@ describe('Fund 2: Asset whitelist, max positions', () => {
               EMPTY_ADDRESS,
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -899,8 +889,7 @@ describe('Fund 2: Asset whitelist, max positions', () => {
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/generalWalkthrough.test.js
+++ b/tests/integration/generalWalkthrough.test.js
@@ -242,10 +242,9 @@ describe('general-walkthrough', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+        ['0x0', '0x0', '0x0', '0x0'],
         orderId,
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        '0x0',
       )
       .send(managerTxOpts);
 
@@ -301,10 +300,9 @@ describe('general-walkthrough', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        ['0x0', '0x0', '0x0', '0x0'],
+        '0x0',
+        '0x0',
       )
       .send(managerTxOpts);
 

--- a/tests/integration/newFundTrading.test.js
+++ b/tests/integration/newFundTrading.test.js
@@ -10,7 +10,7 @@ import web3 from '~/deploy/utils/get-web3';
 
 import { BNExpMul } from '~/tests/utils/BNmath';
 import { CONTRACT_NAMES } from '~/tests/utils/constants';
-import { stringToBytes } from '~/tests/utils/formatting';
+import { numberToBytes, stringToBytes } from '~/tests/utils/formatting';
 import getAllBalances from '~/tests/utils/getAllBalances';
 import getFundComponents from '~/tests/utils/getFundComponents';
 import { getFunctionSignature } from '~/tests/utils/metadata';
@@ -208,8 +208,7 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
           0,
           0,
         ],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -372,11 +371,8 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
           randomHex(20),
         ],
         [0, 0, 0, 0, 0, 0, trade2.buyQuantity, 0],
-        `0x${Number(orderId)
-          .toString(16)
-          .padStart(64, '0')}`,
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
+        numberToBytes(Number(orderId), 32),
         '0x0',
       )
       .send(managerTxOpts);
@@ -440,8 +436,7 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
           0,
           0,
         ],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -460,11 +455,8 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
           randomHex(20),
         ],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        `0x${Number(orderId)
-          .toString(16)
-          .padStart(64, '0')}`,
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
+        numberToBytes(Number(orderId), 32),
         '0x0',
       )
       .send(managerTxOpts);
@@ -512,11 +504,8 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
             randomHex(20),
           ],
           [0, 0, 0, 0, 0, 0, `${ bnBuyQuantity }`, 0],
-          `0x${Number(orderId)
-            .toString(16)
-            .padStart(64, '0')}`,
-          '0x0',
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
+          numberToBytes(Number(orderId), 32),
           '0x0',
         )
         .send(managerTxOpts),

--- a/tests/unit/ethfinexOrder.test.js
+++ b/tests/unit/ethfinexOrder.test.js
@@ -1,6 +1,6 @@
 import { AssetProxyId } from '@0x/types';
 import { orderHashUtils } from '@0x/order-utils';
-import { toWei, padLeft } from 'web3-utils';
+import { toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
@@ -96,9 +96,8 @@ beforeEach(async () => {
       0,
       0,
     ],
-    padLeft('0x0', 64),
-    signedOrder.makerAssetData,
-    signedOrder.takerAssetData,
+    [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+    '0x0',
     signedOrder.signature,
   ).send(defaultTxOpts);
 });
@@ -144,9 +143,8 @@ test('Previously made ethfinex order cancelled and not takeable anymore', async 
       EMPTY_ADDRESS,
     ],
     [0, 0, 0, 0, 0, 0, 0, 0],
+    ['0x0', '0x0', '0x0', '0x0'],
     orderHashHex,
-    '0x0',
-    '0x0',
     '0x0',
   ).send(defaultTxOpts);
 
@@ -181,8 +179,7 @@ test('Withdraw (unwrap) maker asset of cancelled order', async () => {
         EMPTY_ADDRESS,
       ],
       [0, 0, 0, 0, 0, 0, 0, 0],
-      '0x0',
-      '0x0',
+      ['0x0', '0x0', '0x0', '0x0'],
       '0x0',
       '0x0',
     ).send(defaultTxOpts);

--- a/tests/unit/oasisDexOrder.test.js
+++ b/tests/unit/oasisDexOrder.test.js
@@ -7,7 +7,6 @@ import {
   CONTRACT_NAMES,
   EMPTY_ADDRESS
 } from '~/tests/utils/constants';
-import { stringToBytes } from '~/tests/utils/formatting';
 import {
   getEventFromReceipt,
   getFunctionSignature
@@ -71,10 +70,9 @@ describe('make-oasis-dex-order', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        ['0x0', '0x0', '0x0', '0x0'],
+        '0x0',
+        '0x0'
       )
       .send(defaultTxOpts);
 
@@ -102,10 +100,9 @@ describe('make-oasis-dex-order', () => {
             EMPTY_ADDRESS,
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          stringToBytes('0', 32),
-          stringToBytes('0', 32),
-          stringToBytes('0', 32),
-          stringToBytes('0', 32),
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0'
         )
         .send(defaultTxOpts)
     ).rejects.toThrow();
@@ -127,10 +124,9 @@ describe('make-oasis-dex-order', () => {
           EMPTY_ADDRESS,
         ],
         [0, 0, 0, 0, 0, 0, 0, 0],
+        ['0x0', '0x0', '0x0', '0x0'],
         order1Vals.id,
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        '0x0'
       )
       .send(defaultTxOpts);
 
@@ -149,10 +145,9 @@ describe('make-oasis-dex-order', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        ['0x0', '0x0', '0x0', '0x0'],
+        '0x0',
+        '0x0'
       )
       .send(defaultTxOpts);
 

--- a/tests/unit/tradingCallbacks.test.js
+++ b/tests/unit/tradingCallbacks.test.js
@@ -5,6 +5,7 @@ import web3 from '~/deploy/utils/get-web3';
 
 import { CONTRACT_NAMES, EMPTY_ADDRESS } from '~/tests/utils/constants';
 import deployMockSystem from '~/tests/utils/deployMockSystem';
+import { numberToBytes } from '~/tests/utils/formatting';
 import { getFunctionSignature } from '~/tests/utils/metadata';
 
 describe('tradingCallbacks', () => {
@@ -75,12 +76,9 @@ describe('tradingCallbacks', () => {
           EMPTY_ADDRESS,
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        `0x${Number(mockOrderId)
-          .toString(16)
-          .padStart(64, '0')}`,
-        '0x0',
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
+        numberToBytes(mockOrderId, 32),
+        '0x0'
       )
       .send(defaultTxOpts);
 

--- a/tests/unit/zeroExOrder.test.js
+++ b/tests/unit/zeroExOrder.test.js
@@ -88,9 +88,8 @@ describe('make0xOrder', () => {
         0,
         0,
       ],
-      padLeft('0x0', 64),
-      signedOrder.makerAssetData,
-      signedOrder.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     ).send(defaultTxOpts);
 
@@ -162,9 +161,8 @@ describe('make0xOrder', () => {
         0,
         0,
       ],
-      padLeft('0x0', 64),
-      signedOrder.makerAssetData,
-      signedOrder.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     ).send(defaultTxOpts);
 
@@ -187,9 +185,8 @@ describe('make0xOrder', () => {
           EMPTY_ADDRESS,
         ],
         [0, 0, 0, 0, 0, 0, 0, 0],
+        ['0x0', '0x0', '0x0', '0x0'],
         orderHashHex,
-        '0x0',
-        '0x0',
         '0x0',
       ).send(defaultTxOpts);
 
@@ -260,9 +257,8 @@ describe('make0xOrder', () => {
           amount,
           0,
         ],
-        padLeft('0x0', 64),
-        signedOrder.makerAssetData,
-        signedOrder.takerAssetData,
+        [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder.signature,
       ).send(defaultTxOpts);
 


### PR DESCRIPTION
Refactors `bytes makerAssetData` and `bytes takerAssetData` into a `bytes[4] orderData` parameter in `Trading().callOnExchange()`. The extra slots in the array are reserved for `makerFeeAssetData` and `takerFeeAssetData` that are introduced in 0x v3.

Note:
- As `indexed` and `bytes[4]` don't work well together in solidity 0.4.x, I needed to remove `indexed` from two params of `event ExchangeMethodCall`. These need to be restored when we update to solidity 0.5.x (@luongnt95 )