### PR TITLE
refactor: change callOnExchange params to make way for arbitrary maker and taker fee assets

### DIFF
--- a/deploy/scripts/deploy-melon.js
+++ b/deploy/scripts/deploy-melon.js
@@ -68,10 +68,10 @@ const main = async input => {
   await send(registry, 'registerFees', [[ managementFee.options.address, performanceFee.options.address]]);
 
   const sigs = [
-    'makeOrder(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
-    'takeOrder(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
-    'cancelOrder(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
-    'withdrawTokens(address,address[6],uint256[8],bytes32,bytes,bytes,bytes)',
+    'makeOrder(address,address[8],uint256[8],bytes[4],bytes32,bytes)',
+    'takeOrder(address,address[8],uint256[8],bytes[4],bytes32,bytes)',
+    'cancelOrder(address,address[8],uint256[8],bytes[4],bytes32,bytes)',
+    'withdrawTokens(address,address[8],uint256[8],bytes[4],bytes32,bytes)',
   ].map(s => web3.utils.keccak256(s).slice(0,10));
 
   const exchanges = {};

--- a/src/exchanges/EthfinexAdapter.sol
+++ b/src/exchanges/EthfinexAdapter.sol
@@ -25,17 +25,17 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
     /// @notice Make order by pre-approving signatures
     function makeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
-        uint256[8] memory orderValues,
+        address[8] memory orderAddresses,
+        uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory wrappedMakerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public onlyManager notShutDown {
         ensureCanMakeOrder(orderAddresses[2]);
         Hub hub = getHub();
-
-        IZeroExV2.Order memory order = constructOrderStruct(orderAddresses, orderValues, wrappedMakerAssetData, takerAssetData);
+        IZeroExV2.Order memory order = constructOrderStruct(orderAddresses, orderValues, orderData);
+        bytes memory wrappedMakerAssetData = orderData[0];
+        bytes memory takerAssetData = orderData[1];
         address makerAsset = orderAddresses[2];
         address takerAsset = getAssetAddress(takerAssetData);
         require(
@@ -67,10 +67,10 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
             [order.makerAssetAmount, order.takerAssetAmount, uint(0)]
         );
         getTrading().addOpenMakeOrder(
-            targetExchange, 
+            targetExchange,
             makerAsset,
             takerAsset,
-            uint256(orderInfo.orderHash), 
+            uint256(orderInfo.orderHash),
             order.expirationTimeSeconds
         );
         getTrading().addZeroExOrderData(orderInfo.orderHash, order);
@@ -79,11 +79,10 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
     /// @notice Cancel the 0x make order
     function cancelOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
-        uint256[8] memory orderValues,
+        address[8] memory orderAddresses,
+        uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory wrappedMakerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public onlyCancelPermitted(targetExchange, orderAddresses[2]) {
         Hub hub = getHub();
@@ -105,11 +104,10 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
     /// @notice Unwrap (withdraw) tokens, uses orderAddresses for input list of tokens to be unwrapped
     function withdrawTokens(
         address targetExchange,
-        address[6] memory orderAddresses,
-        uint256[8] memory orderValues,
+        address[8] memory orderAddresses,
+        uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public {
         Hub hub = getHub();
@@ -192,10 +190,9 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
     // VIEW METHODS
 
     function constructOrderStruct(
-        address[6] memory orderAddresses,
-        uint256[8] memory orderValues,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData
+        address[8] memory orderAddresses,
+        uint[8] memory orderValues,
+        bytes[4] memory orderData
     )
         internal
         view
@@ -212,8 +209,8 @@ contract EthfinexAdapter is DSMath, ExchangeAdapter {
             takerFee: orderValues[3],
             expirationTimeSeconds: orderValues[4],
             salt: orderValues[5],
-            makerAssetData: makerAssetData,
-            takerAssetData: takerAssetData
+            makerAssetData: orderData[0],
+            takerAssetData: orderData[1]
         });
     }
 

--- a/src/exchanges/ExchangeAdapter.sol
+++ b/src/exchanges/ExchangeAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.5.15;
+pragma experimental ABIEncoderV2;
 
 import "../fund/accounting/Accounting.sol";
 import "../fund/hub/Hub.sol";
@@ -76,6 +77,8 @@ contract ExchangeAdapter {
     /// @param orderAddresses [3] Order taker asset
     /// @param orderAddresses [4] feeRecipientAddress
     /// @param orderAddresses [5] senderAddress
+    /// @param orderAddresses [6] maker fee asset
+    /// @param orderAddresses [7] taker fee asset
     /// @param orderValues [0] makerAssetAmount
     /// @param orderValues [1] takerAssetAmount
     /// @param orderValues [2] Maker fee
@@ -84,9 +87,11 @@ contract ExchangeAdapter {
     /// @param orderValues [5] Salt/nonce
     /// @param orderValues [6] Fill amount: amount of taker token to be traded
     /// @param orderValues [7] Dexy signature mode
+    /// @param orderData [0] Encoded data specific to maker asset
+    /// @param orderData [1] Encoded data specific to taker asset
+    /// @param orderData [2] Encoded data specific to maker asset fee
+    /// @param orderData [3] Encoded data specific to taker asset fee
     /// @param identifier Order identifier
-    /// @param makerAssetData Encoded data specific to makerAsset
-    /// @param takerAssetData Encoded data specific to takerAsset
     /// @param signature Signature of order maker
 
     // Responsibilities of makeOrder are:
@@ -100,11 +105,10 @@ contract ExchangeAdapter {
     // - place asset in ownedAssets if not already tracked
     function makeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public { revert("Unimplemented"); }
 
@@ -121,11 +125,10 @@ contract ExchangeAdapter {
     // - place asset in ownedAssets if not already tracked
     function takeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public { revert("Unimplemented"); }
 
@@ -135,11 +138,10 @@ contract ExchangeAdapter {
     // - cancel order on exchange
     function cancelOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public { revert("Unimplemented"); }
 

--- a/src/exchanges/KyberAdapter.sol
+++ b/src/exchanges/KyberAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.5.15;
+pragma experimental ABIEncoderV2;
 
 import "../dependencies/WETH.sol";
 import "../dependencies/token/IERC20.sol";
@@ -31,11 +32,10 @@ contract KyberAdapter is DSMath, ExchangeAdapter {
     /// @param orderValues [1] Taker asset quantity (Src token amount)
     function takeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public onlyManager notShutDown {
         Hub hub = getHub();

--- a/src/exchanges/OasisDexAdapter.sol
+++ b/src/exchanges/OasisDexAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.5.15;
+pragma experimental ABIEncoderV2;
 
 import "../fund/hub/Hub.sol";
 import "../fund/trading/Trading.sol";
@@ -37,11 +38,10 @@ contract OasisDexAdapter is DSMath, ExchangeAdapter {
     /// @param orderValues [1] Taker token quantity
     function makeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
-        uint256[8] memory orderValues,
+        address[8] memory orderAddresses,
+        uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public onlyManager notShutDown {
         ensureCanMakeOrder(orderAddresses[2]);
@@ -95,11 +95,10 @@ contract OasisDexAdapter is DSMath, ExchangeAdapter {
     /// @param identifier Active order id
     function takeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
-        uint256[8] memory orderValues,
+        address[8] memory orderAddresses,
+        uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public onlyManager notShutDown {
         Hub hub = getHub();
@@ -159,11 +158,10 @@ contract OasisDexAdapter is DSMath, ExchangeAdapter {
     /// @param identifier Order ID on the exchange
     function cancelOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
-        uint256[8] memory orderValues,
+        address[8] memory orderAddresses,
+        uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public onlyCancelPermitted(targetExchange, orderAddresses[2]) {
         Hub hub = getHub();

--- a/src/fund/policies/TradingSignatures.sol
+++ b/src/fund/policies/TradingSignatures.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.5.15;
 
 contract TradingSignatures {
-    bytes4 constant public MAKE_ORDER = 0x79705be7; // makeOrderSignature
-    bytes4 constant public TAKE_ORDER = 0xe51be6e8; // takeOrderSignature
+    bytes4 constant public MAKE_ORDER = 0x5f08e909; // makeOrderSignature
+    bytes4 constant public TAKE_ORDER = 0x63b24ef1; // takeOrderSignature
 }

--- a/src/fund/trading/ITrading.sol
+++ b/src/fund/trading/ITrading.sol
@@ -1,15 +1,18 @@
 pragma solidity 0.5.15;
 
+pragma experimental ABIEncoderV2;
+
+// TODO: Restore indexed params
+
 /// @notice Mediation between a Fund and exchanges
 interface ITrading {
     function callOnExchange(
         uint exchangeIndex,
         string calldata methodSignature,
-        address[6] calldata orderAddresses,
+        address[8] calldata orderAddresses,
         uint[8] calldata orderValues,
+        bytes[4] calldata orderData,
         bytes32 identifier,
-        bytes calldata makerAssetData,
-        bytes calldata takerAssetData,
         bytes calldata signature
     ) external;
 

--- a/src/fund/trading/Trading.sol
+++ b/src/fund/trading/Trading.sol
@@ -182,7 +182,7 @@ contract Trading is DSMath, TokenUser, Spoke, TradingSignatures {
                 );
             }
         }
-        (bool success, ) = exchanges[exchangeIndex].adapter.delegatecall(
+        (bool success, bytes memory returnData) = exchanges[exchangeIndex].adapter.delegatecall(
             abi.encodeWithSignature(
                 methodSignature,
                 exchanges[exchangeIndex].exchange,
@@ -193,7 +193,7 @@ contract Trading is DSMath, TokenUser, Spoke, TradingSignatures {
                 signature
             )
         );
-        require(success, "Delegated call to exchange failed");
+        require(success, string(returnData));
         PolicyManager(routes.policyManager).postValidate(methodSelector, [orderAddresses[0], orderAddresses[1], orderAddresses[2], orderAddresses[3], exchanges[exchangeIndex].exchange], [orderValues[0], orderValues[1], orderValues[6]], identifier);
         emit ExchangeMethodCall(
             exchanges[exchangeIndex].exchange,

--- a/src/fund/trading/Trading.sol
+++ b/src/fund/trading/Trading.sol
@@ -15,11 +15,10 @@ contract Trading is DSMath, TokenUser, Spoke {
     event ExchangeMethodCall(
         address indexed exchangeAddress,
         string indexed methodSignature,
-        address[6] orderAddresses,
+        address[8] orderAddresses,
         uint[8] orderValues,
+        bytes[4] orderData,
         bytes32 identifier,
-        bytes makerAssetData,
-        bytes takerAssetData,
         bytes signature
     );
 
@@ -122,6 +121,8 @@ contract Trading is DSMath, TokenUser, Spoke {
     /// @param orderAddresses [3] Order taker asset
     /// @param orderAddresses [4] feeRecipientAddress
     /// @param orderAddresses [5] senderAddress
+    /// @param orderAddresses [6] maker fee asset
+    /// @param orderAddresses [7] taker fee asset
     /// @param orderValues [0] makerAssetAmount
     /// @param orderValues [1] takerAssetAmount
     /// @param orderValues [2] Maker fee
@@ -130,18 +131,19 @@ contract Trading is DSMath, TokenUser, Spoke {
     /// @param orderValues [5] Salt/nonce
     /// @param orderValues [6] Fill amount: amount of taker token to be traded
     /// @param orderValues [7] Dexy signature mode
+    /// @param orderData [0] Encoded data specific to maker asset
+    /// @param orderData [1] Encoded data specific to taker asset
+    /// @param orderData [2] Encoded data specific to maker asset fee
+    /// @param orderData [3] Encoded data specific to taker asset fee
     /// @param identifier Order identifier
-    /// @param makerAssetData Encoded data specific to makerAsset.
-    /// @param takerAssetData Encoded data specific to takerAsset.
-    /// @param signature Signature of order maker.
+    /// @param signature Signature of order maker
     function callOnExchange(
         uint exchangeIndex,
         string memory methodSignature,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     )
         public
@@ -152,7 +154,8 @@ contract Trading is DSMath, TokenUser, Spoke {
             Registry(routes.registry).adapterMethodIsAllowed(
                 exchanges[exchangeIndex].adapter,
                 methodSelector
-            )
+            ),
+            "Adapter method not allowed"
         );
         PolicyManager(routes.policyManager).preValidate(methodSelector, [orderAddresses[0], orderAddresses[1], orderAddresses[2], orderAddresses[3], exchanges[exchangeIndex].exchange], [orderValues[0], orderValues[1], orderValues[6]], identifier);
         if (
@@ -172,9 +175,8 @@ contract Trading is DSMath, TokenUser, Spoke {
                 exchanges[exchangeIndex].exchange,
                 orderAddresses,
                 orderValues,
+                orderData,
                 identifier,
-                makerAssetData,
-                takerAssetData,
                 signature
             )
         );
@@ -185,9 +187,8 @@ contract Trading is DSMath, TokenUser, Spoke {
             methodSignature,
             orderAddresses,
             orderValues,
+            orderData,
             identifier,
-            makerAssetData,
-            takerAssetData,
             signature
         );
     }

--- a/tests/contracts/MockAdapter.sol
+++ b/tests/contracts/MockAdapter.sol
@@ -1,4 +1,5 @@
 pragma solidity 0.5.15;
+pragma experimental ABIEncoderV2;
 
 import "main/fund/trading/Trading.sol";
 import "main/fund/hub/Hub.sol";
@@ -14,11 +15,10 @@ contract MockAdapter is ExchangeAdapter {
     /// @notice Mock make order
     function makeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public {
         Hub hub = getHub();
@@ -40,11 +40,10 @@ contract MockAdapter is ExchangeAdapter {
     /// @notice Mock take order
     function takeOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public {
         address makerAsset = orderAddresses[2];
@@ -65,11 +64,10 @@ contract MockAdapter is ExchangeAdapter {
     /// @notice Mock cancel order
     function cancelOrder(
         address targetExchange,
-        address[6] memory orderAddresses,
+        address[8] memory orderAddresses,
         uint[8] memory orderValues,
+        bytes[4] memory orderData,
         bytes32 identifier,
-        bytes memory makerAssetData,
-        bytes memory takerAssetData,
         bytes memory signature
     ) public {
         Hub hub = getHub();

--- a/tests/integration/fund0xTrading.test.js
+++ b/tests/integration/fund0xTrading.test.js
@@ -10,7 +10,8 @@
  */
 
 import { orderHashUtils } from '@0x/order-utils';
-import { BN, randomHex, toWei } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
+
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
 import { CONTRACT_NAMES, EMPTY_ADDRESS } from '~/tests/utils/constants';
@@ -174,6 +175,8 @@ describe('fund-0x-trading', () => {
           weth.options.address,
           signedOrder1.feeRecipientAddress,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [
           signedOrder1.makerAssetAmount,
@@ -185,9 +188,8 @@ describe('fund-0x-trading', () => {
           fillQuantity,
           0,
         ],
-        randomHex(32),
-        signedOrder1.makerAssetData,
-        signedOrder1.takerAssetData,
+        [signedOrder1.makerAssetData, signedOrder1.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder1.signature,
       )
       .send(managerTxOpts);
@@ -288,6 +290,8 @@ describe('fund-0x-trading', () => {
           weth.options.address,
           signedOrder2.feeRecipientAddress,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [
           signedOrder2.makerAssetAmount,
@@ -299,9 +303,8 @@ describe('fund-0x-trading', () => {
           fillQuantity,
           0,
         ],
-        randomHex(32),
-        signedOrder2.makerAssetData,
-        signedOrder2.takerAssetData,
+        [signedOrder2.makerAssetData, signedOrder2.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder2.signature,
       )
       .send(managerTxOpts);
@@ -381,6 +384,8 @@ describe('fund-0x-trading', () => {
           takerTokenAddress,
           signedOrder3.feeRecipientAddress,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [
           signedOrder3.makerAssetAmount,
@@ -392,9 +397,8 @@ describe('fund-0x-trading', () => {
           0,
           0,
         ],
-        randomHex(32),
-        signedOrder3.makerAssetData,
-        signedOrder3.takerAssetData,
+        [signedOrder3.makerAssetData, signedOrder3.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder3.signature,
       )
       .send(managerTxOpts);
@@ -510,6 +514,8 @@ describe('fund-0x-trading', () => {
           mln.options.address,
           signedOrder4.feeRecipientAddress,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [
           signedOrder4.makerAssetAmount,
@@ -521,9 +527,8 @@ describe('fund-0x-trading', () => {
           0,
           0,
         ],
-        randomHex(32),
-        signedOrder4.makerAssetData,
-        signedOrder4.takerAssetData,
+        [signedOrder4.makerAssetData, signedOrder4.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder4.signature,
       )
       .send(managerTxOpts);
@@ -554,11 +559,12 @@ describe('fund-0x-trading', () => {
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [0, 0, 0, 0, 0, 0, 0, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
           orderHashHex,
-          '0x0',
-          '0x0',
           '0x0',
         )
         .send(managerTxOpts);

--- a/tests/integration/fundEngineTrading.test.js
+++ b/tests/integration/fundEngineTrading.test.js
@@ -106,10 +106,11 @@ describe('Happy Path', () => {
           mln.options.address,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -154,10 +155,11 @@ describe('Happy Path', () => {
             mln.options.address,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-          '0x0',
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/fundEthfinexTrading.test.js
+++ b/tests/integration/fundEthfinexTrading.test.js
@@ -12,7 +12,7 @@
 
 import { orderHashUtils } from '@0x/order-utils';
 import { AssetProxyId } from '@0x/types';
-import { BN, toWei, randomHex } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
@@ -169,6 +169,8 @@ test('Make order through the fund', async () => {
         weth.options.address,
         order.feeRecipientAddress,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [
         order.makerAssetAmount,
@@ -180,9 +182,8 @@ test('Make order through the fund', async () => {
         0,
         0,
       ],
-      randomHex(32),
-      order.makerAssetData,
-      order.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     )
     .send(managerTxOpts);
@@ -276,6 +277,8 @@ test('Make order with native asset', async () => {
         dgx.options.address,
         signedOrder.feeRecipientAddress,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [
         signedOrder.makerAssetAmount,
@@ -287,9 +290,8 @@ test('Make order with native asset', async () => {
         0,
         0,
       ],
-      randomHex(32),
-      signedOrder.makerAssetData,
-      signedOrder.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     )
     .send(managerTxOpts);
@@ -344,11 +346,12 @@ test('Cancel the order and withdraw tokens', async () => {
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [0, 0, 0, 0, 0, 0, 0, 0],
+      ['0x0', '0x0', '0x0', '0x0'],
       orderHashHex,
-      '0x0',
-      '0x0',
       '0x0',
     )
     .send(managerTxOpts);
@@ -376,10 +379,11 @@ test('Cancel the order and withdraw tokens', async () => {
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [0, 0, 0, 0, 0, 0, 0, 0],
-      randomHex(32),
-      '0x0',
+      ['0x0', '0x0', '0x0', '0x0'],
       '0x0',
       '0x0',
     )

--- a/tests/integration/fundKyberTrading.test.js
+++ b/tests/integration/fundKyberTrading.test.js
@@ -8,7 +8,7 @@
  * @test Fund take order fails with too high maker quantity
  */
 
-import { BN, toWei, randomHex } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
@@ -158,10 +158,11 @@ describe('fund-kyber-trading', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -214,10 +215,11 @@ describe('fund-kyber-trading', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -273,10 +275,11 @@ describe('fund-kyber-trading', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -327,10 +330,11 @@ describe('fund-kyber-trading', () => {
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/fundKyberTrading2.test.js
+++ b/tests/integration/fundKyberTrading2.test.js
@@ -120,10 +120,11 @@ describe('Happy Path', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -171,10 +172,11 @@ describe('Happy Path', () => {
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-          '0x0',
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/fundMultipleExchanges.test.js
+++ b/tests/integration/fundMultipleExchanges.test.js
@@ -148,10 +148,11 @@ test('fund takes an order on Kyber', async () => {
         takerAsset,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
-      '0x0',
-      '0x0',
+      ['0x0', '0x0', '0x0', '0x0'],
       '0x0',
       '0x0',
     )

--- a/tests/integration/fundQuoteAsset.test.js
+++ b/tests/integration/fundQuoteAsset.test.js
@@ -7,11 +7,11 @@
  * @test A fund places a make order with a quote token that is not 18 decimals
  */
 
-import { BN, toWei, randomHex } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
 import { BNExpMul } from '~/tests/utils/BNmath';
-import { CONTRACT_NAMES } from '~/tests/utils/constants';
+import { CONTRACT_NAMES, EMPTY_ADDRESS } from '~/tests/utils/constants';
 import { stringToBytes } from '~/tests/utils/formatting';
 import getFundComponents from '~/tests/utils/getFundComponents';
 import { getFunctionSignature } from '~/tests/utils/metadata';
@@ -317,16 +317,17 @@ describe('fund-quote-asset', () => {
         0,
         makeOrderSignature,
         [
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
           dgx.options.address,
           mln.options.address,
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [trade1.sellQuantity, trade1.buyQuantity, 0, 0, 0, 0, 0, 0],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )

--- a/tests/integration/fundRiskManagement.test.js
+++ b/tests/integration/fundRiskManagement.test.js
@@ -11,7 +11,8 @@
  */
 
 import { encodeFunctionSignature } from 'web3-eth-abi';
-import { BN, hexToNumber, randomHex, toWei } from 'web3-utils';
+import { BN, hexToNumber, toWei } from 'web3-utils';
+
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import { deploy } from '~/deploy/utils/deploy-contract';
 import web3 from '~/deploy/utils/get-web3';
@@ -276,10 +277,11 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
               takerAsset,
               EMPTY_ADDRESS,
               EMPTY_ADDRESS,
+              EMPTY_ADDRESS,
+              EMPTY_ADDRESS
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -309,10 +311,11 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -393,10 +396,11 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
               takerAsset,
               EMPTY_ADDRESS,
               EMPTY_ADDRESS,
+              EMPTY_ADDRESS,
+              EMPTY_ADDRESS
             ],
             [makerQuantity, badTakerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -422,10 +426,11 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, toleratedTakerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -509,10 +514,11 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -569,10 +575,11 @@ describe('Fund 1: Asset blacklist, price tolerance, max positions, max concentra
               takerAsset,
               EMPTY_ADDRESS,
               EMPTY_ADDRESS,
+              EMPTY_ADDRESS,
+              EMPTY_ADDRESS
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -708,10 +715,11 @@ describe('Fund 2: Asset whitelist, max positions', () => {
               takerAsset,
               EMPTY_ADDRESS,
               EMPTY_ADDRESS,
+              EMPTY_ADDRESS,
+              EMPTY_ADDRESS
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -743,10 +751,11 @@ describe('Fund 2: Asset whitelist, max positions', () => {
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )
@@ -818,11 +827,12 @@ describe('Fund 2: Asset whitelist, max positions', () => {
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
           orderId,
-          '0x0',
-          '0x0',
           '0x0',
         )
         .send(managerTxOpts)
@@ -857,10 +867,11 @@ describe('Fund 2: Asset whitelist, max positions', () => {
               takerAsset,
               EMPTY_ADDRESS,
               EMPTY_ADDRESS,
+              EMPTY_ADDRESS,
+              EMPTY_ADDRESS
             ],
             [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-            randomHex(32),
-            '0x0',
+            ['0x0', '0x0', '0x0', '0x0'],
             '0x0',
             '0x0',
           )
@@ -893,10 +904,11 @@ describe('Fund 2: Asset whitelist, max positions', () => {
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          randomHex(32),
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
           '0x0',
           '0x0',
         )

--- a/tests/integration/generalWalkthrough.test.js
+++ b/tests/integration/generalWalkthrough.test.js
@@ -229,12 +229,13 @@ describe('general-walkthrough', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+        ['0x0', '0x0', '0x0', '0x0'],
         orderId,
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        '0x0',
       )
       .send(managerTxOpts);
 
@@ -288,12 +289,13 @@ describe('general-walkthrough', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        ['0x0', '0x0', '0x0', '0x0'],
+        '0x0',
+        '0x0',
       )
       .send(managerTxOpts);
 

--- a/tests/integration/newFundTrading.test.js
+++ b/tests/integration/newFundTrading.test.js
@@ -3,12 +3,13 @@
  */
 
 import { encodeFunctionSignature } from 'web3-eth-abi';
-import { BN, toWei, randomHex } from 'web3-utils';
+import { BN, toWei } from 'web3-utils';
+
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
 import { BNExpMul } from '~/tests/utils/BNmath';
-import { CONTRACT_NAMES } from '~/tests/utils/constants';
-import { stringToBytes } from '~/tests/utils/formatting';
+import { CONTRACT_NAMES, EMPTY_ADDRESS } from '~/tests/utils/constants';
+import { numberToBytes, stringToBytes } from '~/tests/utils/formatting';
 import getAllBalances from '~/tests/utils/getAllBalances';
 import getFundComponents from '~/tests/utils/getFundComponents';
 import { getFunctionSignature } from '~/tests/utils/metadata';
@@ -189,12 +190,14 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
         i,
         makeOrderSignature,
         [
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
           weth.options.address,
           mln.options.address,
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [
           trade1.sellQuantity,
@@ -206,8 +209,7 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
           0,
           0,
         ],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -362,19 +364,18 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
         i,
         takeOrderSignature,
         [
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
           weth.options.address,
           mln.options.address,
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [0, 0, 0, 0, 0, 0, trade2.buyQuantity, 0],
-        `0x${Number(orderId)
-          .toString(16)
-          .padStart(64, '0')}`,
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
+        numberToBytes(Number(orderId), 32),
         '0x0',
       )
       .send(managerTxOpts);
@@ -421,12 +422,14 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
         i,
         makeOrderSignature,
         [
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
           weth.options.address,
           mln.options.address,
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [
           trade2.sellQuantity,
@@ -438,8 +441,7 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
           0,
           0,
         ],
-        randomHex(32),
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
         '0x0',
         '0x0',
       )
@@ -450,19 +452,18 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
         i,
         cancelOrderSignature,
         [
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
           weth.options.address,
           mln.options.address,
-          randomHex(20),
-          randomHex(20),
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [0, 0, 0, 0, 0, 0, 0, 0],
-        `0x${Number(orderId)
-          .toString(16)
-          .padStart(64, '0')}`,
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
+        numberToBytes(Number(orderId), 32),
         '0x0',
       )
       .send(managerTxOpts);
@@ -502,19 +503,18 @@ Array.from(Array(numberOfExchanges).keys()).forEach(i => {
           i,
           takeOrderSignature,
           [
-            randomHex(20),
-            randomHex(20),
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
             weth.options.address,
             mln.options.address,
-            randomHex(20),
-            randomHex(20),
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [0, 0, 0, 0, 0, 0, `${ bnBuyQuantity }`, 0],
-          `0x${Number(orderId)
-            .toString(16)
-            .padStart(64, '0')}`,
-          '0x0',
-          '0x0',
+          ['0x0', '0x0', '0x0', '0x0'],
+          numberToBytes(Number(orderId), 32),
           '0x0',
         )
         .send(managerTxOpts),

--- a/tests/mock/tradingCallbacks.test.js
+++ b/tests/mock/tradingCallbacks.test.js
@@ -5,6 +5,7 @@ import web3 from '~/deploy/utils/get-web3';
 
 import { CONTRACT_NAMES, EMPTY_ADDRESS } from '~/tests/utils/constants';
 import deployMockSystem from '~/tests/utils/deployMockSystem';
+import { numberToBytes } from '~/tests/utils/formatting';
 import { getFunctionSignature } from '~/tests/utils/metadata';
 
 describe('tradingCallbacks', () => {
@@ -73,14 +74,13 @@ describe('tradingCallbacks', () => {
           mockSystem.weth.options.address,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        `0x${Number(mockOrderId)
-          .toString(16)
-          .padStart(64, '0')}`,
-        '0x0',
-        '0x0',
-        '0x0',
+        ['0x0', '0x0', '0x0', '0x0'],
+        numberToBytes(mockOrderId, 32),
+        '0x0'
       )
       .send(defaultTxOpts);
 

--- a/tests/unit/exchanges/ethfinexOrder.test.js
+++ b/tests/unit/exchanges/ethfinexOrder.test.js
@@ -1,6 +1,6 @@
 import { AssetProxyId } from '@0x/types';
 import { orderHashUtils } from '@0x/order-utils';
-import { toWei, padLeft } from 'web3-utils';
+import { toWei } from 'web3-utils';
 
 import { partialRedeploy } from '~/deploy/scripts/deploy-system';
 import web3 from '~/deploy/utils/get-web3';
@@ -85,6 +85,8 @@ beforeEach(async () => {
       mln.options.address,
       signedOrder.feeRecipientAddress,
       EMPTY_ADDRESS,
+      EMPTY_ADDRESS,
+      EMPTY_ADDRESS
     ],
     [
       signedOrder.makerAssetAmount,
@@ -96,9 +98,8 @@ beforeEach(async () => {
       0,
       0,
     ],
-    padLeft('0x0', 64),
-    signedOrder.makerAssetData,
-    signedOrder.takerAssetData,
+    [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+    '0x0',
     signedOrder.signature,
   ).send(defaultTxOpts);
 });
@@ -142,11 +143,12 @@ test('Previously made ethfinex order cancelled and not takeable anymore', async 
       EMPTY_ADDRESS,
       EMPTY_ADDRESS,
       EMPTY_ADDRESS,
+      EMPTY_ADDRESS,
+      EMPTY_ADDRESS
     ],
     [0, 0, 0, 0, 0, 0, 0, 0],
+    ['0x0', '0x0', '0x0', '0x0'],
     orderHashHex,
-    '0x0',
-    '0x0',
     '0x0',
   ).send(defaultTxOpts);
 
@@ -179,10 +181,11 @@ test('Withdraw (unwrap) maker asset of cancelled order', async () => {
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [0, 0, 0, 0, 0, 0, 0, 0],
-      '0x0',
-      '0x0',
+      ['0x0', '0x0', '0x0', '0x0'],
       '0x0',
       '0x0',
     ).send(defaultTxOpts);

--- a/tests/unit/exchanges/oasisDexOrder.test.js
+++ b/tests/unit/exchanges/oasisDexOrder.test.js
@@ -7,7 +7,6 @@ import {
   CONTRACT_NAMES,
   EMPTY_ADDRESS
 } from '~/tests/utils/constants';
-import { stringToBytes } from '~/tests/utils/formatting';
 import {
   getEventFromReceipt,
   getFunctionSignature
@@ -69,12 +68,13 @@ describe('make-oasis-dex-order', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        ['0x0', '0x0', '0x0', '0x0'],
+        '0x0',
+        '0x0'
       )
       .send(defaultTxOpts);
 
@@ -100,12 +100,13 @@ describe('make-oasis-dex-order', () => {
             takerAsset,
             EMPTY_ADDRESS,
             EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
           ],
           [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-          stringToBytes('0', 32),
-          stringToBytes('0', 32),
-          stringToBytes('0', 32),
-          stringToBytes('0', 32),
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0'
         )
         .send(defaultTxOpts)
     ).rejects.toThrow();
@@ -125,12 +126,13 @@ describe('make-oasis-dex-order', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [0, 0, 0, 0, 0, 0, 0, 0],
+        ['0x0', '0x0', '0x0', '0x0'],
         order1Vals.id,
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        '0x0'
       )
       .send(defaultTxOpts);
 
@@ -147,12 +149,13 @@ describe('make-oasis-dex-order', () => {
           takerAsset,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [makerQuantity, takerQuantity, 0, 0, 0, 0, 0, 0],
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
-        stringToBytes('0', 32),
+        ['0x0', '0x0', '0x0', '0x0'],
+        '0x0',
+        '0x0'
       )
       .send(defaultTxOpts);
 

--- a/tests/unit/exchanges/zeroExOrder.test.js
+++ b/tests/unit/exchanges/zeroExOrder.test.js
@@ -77,6 +77,8 @@ describe('make0xOrder', () => {
         takerToken.options.address,
         signedOrder.feeRecipientAddress,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [
         signedOrder.makerAssetAmount,
@@ -88,9 +90,8 @@ describe('make0xOrder', () => {
         0,
         0,
       ],
-      padLeft('0x0', 64),
-      signedOrder.makerAssetData,
-      signedOrder.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     ).send(defaultTxOpts);
 
@@ -151,6 +152,8 @@ describe('make0xOrder', () => {
         takerToken.options.address,
         signedOrder.feeRecipientAddress,
         EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS
       ],
       [
         signedOrder.makerAssetAmount,
@@ -162,9 +165,8 @@ describe('make0xOrder', () => {
         0,
         0,
       ],
-      padLeft('0x0', 64),
-      signedOrder.makerAssetData,
-      signedOrder.takerAssetData,
+      [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+      '0x0',
       signedOrder.signature,
     ).send(defaultTxOpts);
 
@@ -185,11 +187,12 @@ describe('make0xOrder', () => {
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [0, 0, 0, 0, 0, 0, 0, 0],
+        ['0x0', '0x0', '0x0', '0x0'],
         orderHashHex,
-        '0x0',
-        '0x0',
         '0x0',
       ).send(defaultTxOpts);
 
@@ -249,6 +252,8 @@ describe('make0xOrder', () => {
           takerToken.options.address,
           signedOrder.feeRecipientAddress,
           EMPTY_ADDRESS,
+          EMPTY_ADDRESS,
+          EMPTY_ADDRESS
         ],
         [
           signedOrder.makerAssetAmount,
@@ -260,9 +265,8 @@ describe('make0xOrder', () => {
           amount,
           0,
         ],
-        padLeft('0x0', 64),
-        signedOrder.makerAssetData,
-        signedOrder.takerAssetData,
+        [signedOrder.makerAssetData, signedOrder.takerAssetData, '0x0', '0x0'],
+        '0x0',
         signedOrder.signature,
       ).send(defaultTxOpts);
 

--- a/tests/unit/fund/trading/callOnExchange.test.js
+++ b/tests/unit/fund/trading/callOnExchange.test.js
@@ -1,0 +1,344 @@
+/*
+ * @file Tests funds trading via the mock adapter.
+ * @dev This allows checking policies and other proprietary requirements without needing to satisfy exchange requirements
+ *
+ * @test Fund can NOT trade when maker or taker asset NOT in Registry
+ * @test Fund can NOT TAKE order when TAKER fee asset NOT in Registry
+ * @test Fund can TAKE order when MAKER fee asset NOT in Registry
+ * @test Fund can NOT MAKE order when MAKER fee asset NOT in Registry
+ * @test Fund can MAKE order when TAKER fee asset NOT in Registry
+ */
+
+import { encodeFunctionSignature } from 'web3-eth-abi';
+import { BN, randomHex, toWei } from 'web3-utils';
+
+import { partialRedeploy } from '~/deploy/scripts/deploy-system';
+import { deploy } from '~/deploy/utils/deploy-contract';
+import web3 from '~/deploy/utils/get-web3';
+
+import { CONTRACT_NAMES, EMPTY_ADDRESS } from '~/tests/utils/constants';
+import { stringToBytes } from '~/tests/utils/formatting';
+import getFundComponents from '~/tests/utils/getFundComponents';
+import { getFunctionSignature } from '~/tests/utils/metadata';
+
+let defaultTxOpts, managerTxOpts;
+let deployer, manager, investor;
+let contracts, deployOut;
+let exchangeIndex, makeOrderSignature, takeOrderSignature;
+let weth, mln;
+let fund;
+
+beforeAll(async () => {
+  const accounts = await web3.eth.getAccounts();
+  [deployer, manager, investor] = accounts;
+  defaultTxOpts = { from: deployer, gas: 8000000 };
+  managerTxOpts = { ...defaultTxOpts, from: manager };
+
+  // Define vars - orders
+  exchangeIndex = 0;
+  makeOrderSignature = getFunctionSignature(
+    CONTRACT_NAMES.EXCHANGE_ADAPTER,
+    'makeOrder'
+  );
+  takeOrderSignature = getFunctionSignature(
+    CONTRACT_NAMES.EXCHANGE_ADAPTER,
+    'takeOrder'
+  );
+});
+
+beforeEach(async () => {
+
+  const deployed = await partialRedeploy([CONTRACT_NAMES.VERSION]);
+  contracts = deployed.contracts;
+  deployOut = deployed.deployOut;
+
+  const registry = contracts.Registry;
+  const version = contracts.Version;
+  weth = contracts.WETH;
+  mln = contracts.MLN;
+
+  // Register a mock exchange and adapter
+  const mockExchangeAddress = randomHex(20);
+  const mockAdapter = await deploy(CONTRACT_NAMES.MOCK_ADAPTER);
+  const takesCustody = false;
+  const sigs = [
+    encodeFunctionSignature(makeOrderSignature),
+    encodeFunctionSignature(takeOrderSignature)
+  ];
+  await registry.methods
+    .registerExchangeAdapter(
+      mockExchangeAddress,
+      mockAdapter.options.address,
+      takesCustody,
+      sigs
+    )
+    .send(defaultTxOpts);
+
+  // Startup a fund
+  await version.methods
+    .beginSetup(
+      stringToBytes('Test fund', 32),
+      [],
+      [],
+      [],
+      [mockExchangeAddress],
+      [mockAdapter.options.address],
+      weth.options.address.toString(),
+      [mln.options.address.toString(), weth.options.address.toString()],
+    ).send(managerTxOpts);
+
+  await version.methods.createAccounting().send(managerTxOpts);
+  await version.methods.createFeeManager().send(managerTxOpts);
+  await version.methods.createParticipation().send(managerTxOpts);
+  await version.methods.createPolicyManager().send(managerTxOpts);
+  await version.methods.createShares().send(managerTxOpts);
+  await version.methods.createTrading().send(managerTxOpts);
+  await version.methods.createVault().send(managerTxOpts);
+  const res = await version.methods.completeSetup().send(managerTxOpts);
+  const hubAddress = res.events.NewFund.returnValues.hub;
+  fund = await getFundComponents(hubAddress);
+
+  // Seed investor with weth and invest in fund
+  await weth.methods
+    .transfer(investor, toWei('1', 'ether'))
+    .send(defaultTxOpts);
+
+  const investorTxOpts = { ...defaultTxOpts, from: investor };
+  const offeredValue = toWei('1', 'ether');
+  const wantedShares = toWei('1', 'ether');
+  const amguAmount = toWei('.01', 'ether');
+  await weth.methods
+    .approve(fund.participation.options.address, offeredValue)
+    .send(investorTxOpts);
+  await fund.participation.methods
+    .requestInvestment(offeredValue, wantedShares, weth.options.address)
+    .send({ ...investorTxOpts, value: amguAmount });
+  await fund.participation.methods
+    .executeRequestFor(investor)
+    .send(investorTxOpts);
+});
+
+describe('Asset in Registry', () => {
+  it('can NOT trade when maker or taker asset NOT in Registry', async () => {
+    const { trading } = fund;
+
+    const makerQuantity = 100;
+    const takerQuantity = 200;
+
+    // Make orders
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          makeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            randomHex(20),
+            weth.options.address,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).rejects.toThrow("Maker asset not registered");
+
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          makeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            weth.options.address,
+            randomHex(20),
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).rejects.toThrow("Taker asset not registered");
+
+    // Take orders
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          takeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            randomHex(20),
+            weth.options.address,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).rejects.toThrow("Maker asset not registered");
+
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          takeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            weth.options.address,
+            randomHex(20),
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).rejects.toThrow("Taker asset not registered");
+  });
+
+  it('can NOT MAKE order when MAKER fee asset NOT in Registry', async () => {
+    const { trading } = fund;
+
+    const makerQuantity = 100;
+    const takerQuantity = 200;
+
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          makeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            weth.options.address,
+            mln.options.address,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            randomHex(20),
+            EMPTY_ADDRESS
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).rejects.toThrow("Maker fee asset not registered");
+  });
+
+  it('can MAKE order when TAKER fee asset NOT in Registry', async () => {
+    const { trading } = fund;
+
+    const makerQuantity = 100;
+    const takerQuantity = 200;
+
+    // Take order
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          makeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            weth.options.address,
+            mln.options.address,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            mln.options.address,
+            randomHex(20)
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).resolves.not.toThrow();
+  });
+
+  it('can NOT TAKE order when TAKER fee asset NOT in Registry', async () => {
+    const { trading } = fund;
+
+    const makerQuantity = 100;
+    const takerQuantity = 200;
+
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          takeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            weth.options.address,
+            mln.options.address,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            randomHex(20),
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).rejects.toThrow("Taker fee asset not registered");
+  });
+
+  it('can TAKE order when MAKER fee asset NOT in Registry', async () => {
+    const { trading } = fund;
+
+    const makerQuantity = 100;
+    const takerQuantity = 200;
+
+    // Take order
+    await expect(
+      trading.methods
+        .callOnExchange(
+          exchangeIndex,
+          takeOrderSignature,
+          [
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            weth.options.address,
+            mln.options.address,
+            EMPTY_ADDRESS,
+            EMPTY_ADDRESS,
+            randomHex(20),
+            weth.options.address
+          ],
+          [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+          ['0x0', '0x0', '0x0', '0x0'],
+          '0x0',
+          '0x0',
+        )
+        .send(managerTxOpts)
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
Addresses issue https://github.com/melonproject/protocol/issues/842.

Further changes:
- `Trading` inherits `TradingSignatures` instead of using own hard-coded encoded function sig storage vars
- `callOnExchange`'s `delegatecall` now returns actual revert messages