### PR TITLE
feature: fund can add an exchange post-creation

### DIFF
--- a/src/fund/hub/Hub.sol
+++ b/src/fund/hub/Hub.sol
@@ -109,6 +109,7 @@ contract Hub is DSGuard {
         permit(manager, routes.policyManager, bytes4(keccak256('batchRegister(bytes4[],address[])')));
         permit(manager, routes.participation, bytes4(keccak256('enableInvestment(address[])')));
         permit(manager, routes.participation, bytes4(keccak256('disableInvestment(address[])')));
+        permit(manager, routes.trading, bytes4(keccak256('addExchange(address,address)')));
         permissionsSet = true;
     }
 

--- a/src/fund/trading/Trading.sol
+++ b/src/fund/trading/Trading.sol
@@ -86,6 +86,10 @@ contract Trading is DSMath, TokenUser, Spoke {
     /// @notice Fallback function to receive ETH from WETH
     function() external payable {}
 
+    function addExchange(address _exchange, address _adapter) external auth {
+        _addExchange(_exchange, _adapter);
+    }
+
     function _addExchange(
         address _exchange,
         address _adapter

--- a/tests/integration/fundMultipleExchanges.test.js
+++ b/tests/integration/fundMultipleExchanges.test.js
@@ -1,0 +1,169 @@
+/*
+ * @file Tests a fund trading with multiple exchange adapters
+ *
+ * @test A fund can add an exchange adapter after it is created
+ * @test A fund can take an order with the newly-added exchange
+ * @test TODO: multiple tests for make and take orders on multiple exchanges
+ */
+
+import { encodeFunctionSignature } from 'web3-eth-abi';
+import { BN, toWei } from 'web3-utils';
+import { partialRedeploy } from '~/deploy/scripts/deploy-system';
+import web3 from '~/deploy/utils/get-web3';
+
+import { BNExpMul } from '~/tests/utils/BNmath';
+import { CONTRACT_NAMES, EMPTY_ADDRESS, KYBER_ETH_ADDRESS } from '~/tests/utils/constants';
+import { stringToBytes } from '~/tests/utils/formatting';
+import getFundComponents from '~/tests/utils/getFundComponents';
+import { getFunctionSignature } from '~/tests/utils/metadata';
+
+let deployer, manager, investor;
+let defaultTxOpts, managerTxOpts, investorTxOpts;
+let makeOrderFunctionSig, takeOrderFunctionSig;
+let mln, weth;
+let oasisDex, oasisDexAdapter, oasisDexExchangeIndex;
+let kyberNetworkProxy, kyberAdapter, kyberExchangeIndex;
+let version, fund;
+
+beforeAll(async () => {
+  [deployer, manager, investor] = await web3.eth.getAccounts();
+  defaultTxOpts = { from: deployer, gas: 8000000 };
+  managerTxOpts = { ...defaultTxOpts, from: manager };
+  investorTxOpts = { ...defaultTxOpts, from: investor };
+
+  const deployed = await partialRedeploy([CONTRACT_NAMES.VERSION]);
+  const contracts = deployed.contracts;
+
+  makeOrderFunctionSig = getFunctionSignature(
+    CONTRACT_NAMES.EXCHANGE_ADAPTER,
+    'makeOrder',
+  );
+  takeOrderFunctionSig = getFunctionSignature(
+    CONTRACT_NAMES.EXCHANGE_ADAPTER,
+    'takeOrder',
+  );
+
+  mln = contracts.MLN;
+  version = contracts.Version;
+  weth = contracts.WETH;
+
+  oasisDex = contracts.OasisDexExchange;
+  oasisDexAdapter = contracts.OasisDexAdapter;
+  oasisDexExchangeIndex = 0;
+
+  kyberNetworkProxy = contracts.KyberNetworkProxy;
+  kyberAdapter = contracts.KyberAdapter;
+
+  // Setup fund
+  await version.methods
+    .beginSetup(
+      stringToBytes('Test fund', 32),
+      [],
+      [],
+      [],
+      [oasisDex.options.address],
+      [oasisDexAdapter.options.address],
+      weth.options.address,
+      [mln.options.address, weth.options.address],
+    ).send(managerTxOpts);
+  await version.methods.createAccounting().send(managerTxOpts);
+  await version.methods.createFeeManager().send(managerTxOpts);
+  await version.methods.createParticipation().send(managerTxOpts);
+  await version.methods.createPolicyManager().send(managerTxOpts);
+  await version.methods.createShares().send(managerTxOpts);
+  await version.methods.createTrading().send(managerTxOpts);
+  await version.methods.createVault().send(managerTxOpts);
+  const res = await version.methods.completeSetup().send(managerTxOpts);
+  const hubAddress = res.events.NewFund.returnValues.hub;
+  fund = await getFundComponents(hubAddress);
+
+  // Seed investor with weth and invest in fund
+  const offeredValue = toWei('1', 'ether');
+  const wantedShares = toWei('1', 'ether');
+  const amguAmount = toWei('.01', 'ether');
+  await weth.methods
+    .transfer(investor, offeredValue)
+    .send(defaultTxOpts);
+  await weth.methods
+    .approve(fund.participation.options.address, offeredValue)
+    .send(investorTxOpts);
+  await fund.participation.methods
+    .requestInvestment(offeredValue, wantedShares, weth.options.address)
+    .send({ ...investorTxOpts, value: amguAmount });
+  await fund.participation.methods
+    .executeRequestFor(investor)
+    .send(investorTxOpts);
+});
+
+test("add Kyber to fund's allowed exchanges", async () => {
+  const { trading } = fund;
+
+  const preAddExchangeCount = (await trading.methods.getExchangeInfo().call())[0].length;
+
+  await trading.methods
+    .addExchange(kyberNetworkProxy.options.address, kyberAdapter.options.address)
+    .send(managerTxOpts);
+
+  const exchangeInfo = await fund.trading.methods
+    .getExchangeInfo()
+    .call();
+  kyberExchangeIndex = exchangeInfo[1].findIndex(
+    e => e.toLowerCase() === kyberAdapter.options.address.toLowerCase()
+  );
+
+  expect(kyberExchangeIndex).toBe(preAddExchangeCount);
+});
+
+test('fund takes an order on Kyber', async () => {
+  const { trading, vault } = fund;
+
+  const takerAsset = weth.options.address;
+  const takerQuantity = toWei('0.1', 'ether');
+  const makerAsset = mln.options.address;
+
+  const { 0: expectedRate } = await kyberNetworkProxy.methods
+    .getExpectedRate(KYBER_ETH_ADDRESS, makerAsset, takerQuantity)
+    .call(defaultTxOpts);
+
+  const makerQuantity = BNExpMul(
+    new BN(takerQuantity.toString()),
+    new BN(expectedRate.toString()),
+  ).toString();
+
+  const preMlnVault = new BN(
+    await mln.methods.balanceOf(vault.options.address).call()
+  );
+  const preWethVault = new BN(
+    await weth.methods.balanceOf(vault.options.address).call()
+  );
+
+  await trading.methods
+    .callOnExchange(
+      kyberExchangeIndex,
+      takeOrderFunctionSig,
+      [
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+        makerAsset,
+        takerAsset,
+        EMPTY_ADDRESS,
+        EMPTY_ADDRESS,
+      ],
+      [makerQuantity, takerQuantity, 0, 0, 0, 0, takerQuantity, 0],
+      '0x0',
+      '0x0',
+      '0x0',
+      '0x0',
+    )
+    .send(managerTxOpts);
+
+  const postMlnVault = new BN(
+    await mln.methods.balanceOf(vault.options.address).call()
+  );
+  const postWethVault = new BN(
+    await weth.methods.balanceOf(vault.options.address).call()
+  );
+
+  expect(postWethVault).bigNumberEq(preWethVault.sub(new BN(takerQuantity)));
+  expect(postMlnVault).bigNumberEq(preMlnVault.add(new BN(makerQuantity)));
+});

--- a/tests/unit/fund/trading/trading.test.js
+++ b/tests/unit/fund/trading/trading.test.js
@@ -1,0 +1,81 @@
+/*
+ * @file Tests Trading contract functions and events
+ *
+ * @test addExchange()
+ */
+
+import { encodeFunctionSignature } from 'web3-eth-abi';
+import { randomHex, toWei } from 'web3-utils';
+
+import { partialRedeploy } from '~/deploy/scripts/deploy-system';
+import web3 from '~/deploy/utils/get-web3';
+
+import { CONTRACT_NAMES } from '~/tests/utils/constants';
+import { setupFundWithParams } from '~/tests/utils/fund';
+
+let defaultTxOpts, managerTxOpts;
+let deployer, manager, investor, maliciousUser;
+let contracts, deployOut;
+let weth, mln, registry;
+let fund;
+
+beforeAll(async () => {
+  const accounts = await web3.eth.getAccounts();
+  [deployer, manager, investor, maliciousUser] = accounts;
+  defaultTxOpts = { from: deployer, gas: 8000000 };
+  managerTxOpts = { ...defaultTxOpts, from: manager };
+});
+
+describe('addExchange', () => {
+  let newAdapter, newExchange;
+  let addExchangeRequest;
+
+  beforeAll(async () => {
+    const deployed = await partialRedeploy([CONTRACT_NAMES.VERSION]);
+    contracts = deployed.contracts;
+    deployOut = deployed.deployOut;
+
+    weth = contracts.WETH;
+    mln = contracts.MLN;
+    registry = contracts.Registry;
+
+    const version = contracts.Version;
+    const oasisDexExchange = contracts.OasisDexExchange;
+    const oasisDexAdapter = contracts.OasisDexAdapter;
+
+    fund = await setupFundWithParams({
+      defaultTokens: [mln.options.address, weth.options.address],
+      exchanges: [oasisDexExchange.options.address],
+      exchangeAdapters: [oasisDexAdapter.options.address],
+      manager,
+      quoteToken: weth.options.address,
+      version
+    });
+
+    newExchange = randomHex(20);
+    newAdapter = randomHex(20);
+    addExchangeRequest = fund.trading.methods.addExchange(newExchange, newAdapter);
+  });
+
+  it('does not allow unauthorized user', async () => {
+    await expect(
+      addExchangeRequest.send({ ...defaultTxOpts, from: maliciousUser })
+    ).rejects.toThrow("ds-auth-unauthorized");
+  });
+
+  it('does not allow un-registered adapter', async () => {
+    await expect(addExchangeRequest.send(managerTxOpts)).rejects.toThrow("Adapter is not registered");
+  });
+
+  it('allows an authenticated user to add a registered exchange adapter', async () => {
+    await registry.methods
+      .registerExchangeAdapter(newExchange, newAdapter, false, [])
+      .send(defaultTxOpts);
+
+    await addExchangeRequest.send(managerTxOpts);
+  });
+
+  it('does not allow a previously-added exchange', async () => {
+    await expect(addExchangeRequest.send(managerTxOpts)).rejects.toThrow("Adapter already added");
+  });
+})

--- a/tests/utils/fund.js
+++ b/tests/utils/fund.js
@@ -1,0 +1,90 @@
+import { BN, randomHex, toWei } from 'web3-utils';
+
+import web3 from '~/deploy/utils/get-web3';
+import { BNExpDiv } from '~/tests/utils/BNmath';
+import getFundComponents from '~/tests/utils/getFundComponents';
+
+export const setupFundWithParams = async ({
+  defaultTokens,
+  exchanges = [],
+  exchangeAdapters = [],
+  initialInvestment = {
+    contribAmount: 0,
+    investor: undefined,
+    tokenContract: undefined
+  },
+  manager,
+  name = randomHex(32),
+  quoteToken,
+  version
+}) => {
+  const managerTxOpts = { from: manager, gas: 8000000 };
+  await version.methods
+    .beginSetup(
+      name,
+      [],
+      [],
+      [],
+      exchanges,
+      exchangeAdapters,
+      quoteToken,
+      defaultTokens,
+    ).send(managerTxOpts);
+
+  await version.methods.createAccounting().send(managerTxOpts);
+  await version.methods.createFeeManager().send(managerTxOpts);
+  await version.methods.createParticipation().send(managerTxOpts);
+  await version.methods.createPolicyManager().send(managerTxOpts);
+  await version.methods.createShares().send(managerTxOpts);
+  await version.methods.createTrading().send(managerTxOpts);
+  await version.methods.createVault().send(managerTxOpts);
+  const res = await version.methods.completeSetup().send(managerTxOpts);
+  const hubAddress = res.events.NewFund.returnValues.hub;
+  const fund = await getFundComponents(hubAddress);
+
+  // Make initial investment, if applicable
+  if (new BN(initialInvestment.contribAmount).gt(new BN(0))) {
+    const investorTxOpts = { ...managerTxOpts, from: initialInvestment.investor };
+    const amguAmount = toWei('.01', 'ether');
+
+    // Calculate amount of shares to buy with contribution
+    const shareCost = new BN(
+      await fund.accounting.methods
+        .getShareCostInAsset(toWei('1', 'ether'), initialInvestment.tokenContract.options.address)
+        .call()
+    );
+    const wantedShares = BNExpDiv(new BN(initialInvestment.contribAmount), shareCost).toString();
+
+    // Fund investor with contribution token, if necessary
+    const investorTokenBalance = new BN(
+      await initialInvestment.tokenContract.methods
+        .balanceOf(initialInvestment.investor)
+        .call()
+    );
+    const investorTokenShortfall =
+      new BN(initialInvestment.contribAmount).sub(investorTokenBalance);
+    if (investorTokenShortfall.gt(new BN(0))) {
+      const [deployer] = await web3.eth.getAccounts();
+      await initialInvestment.tokenContract.methods
+        .transfer(initialInvestment.investor, investorTokenShortfall.toString())
+        .send({ ...managerTxOpts, from: deployer });
+    }
+
+    // Invest in fund
+    await initialInvestment.tokenContract.methods
+      .approve(fund.participation.options.address, initialInvestment.contribAmount)
+      .send(investorTxOpts);
+    await fund.participation.methods
+      .requestInvestment(
+        wantedShares,
+        initialInvestment.contribAmount,
+        initialInvestment.tokenContract.options.address
+      )
+      .send({ ...investorTxOpts, value: amguAmount });
+    await fund.participation.methods
+      .executeRequestFor(initialInvestment.investor)
+      .send(investorTxOpts);
+  }
+
+  return fund;
+}


### PR DESCRIPTION
Addresses issue #811 

This PR also adds:
- a `fundMultipleExchanges.test.js` integration test
- a `fund.js` test util file with a `setupFundWithParams` helper that makes setting up funds (invested in or not) simple