### PR TITLE
Allow anyone to continue setup of a fund for another

### DIFF
--- a/src/factory/FundFactory.sol
+++ b/src/factory/FundFactory.sol
@@ -49,22 +49,6 @@ contract FundFactory is AmguConsumer, Factory {
         uint[] feePeriods;
     }
 
-    modifier componentNotSet(address _component) {
-        require(
-            !componentExists(_component),
-            "This step has already been run"
-        );
-        _;
-    }
-
-    modifier componentSet(address _component) {
-        require(
-            componentExists(_component),
-            "Component preprequisites not met"
-        );
-        _;
-    }
-
     constructor(
         address _accountingFactory,
         address _feeManagerFactory,
@@ -91,6 +75,20 @@ contract FundFactory is AmguConsumer, Factory {
         return _component != address(0);
     }
 
+    function ensureComponentNotSet(address _component) internal {
+        require(
+            !componentExists(_component),
+            "This step has already been run"
+        );
+    }
+
+    function ensureComponentSet(address _component) internal {
+        require(
+            componentExists(_component),
+            "Component preprequisites not met"
+        );
+    }
+
     function beginSetup(
         string memory _name,
         address[] memory _fees,
@@ -102,8 +100,8 @@ contract FundFactory is AmguConsumer, Factory {
         address[] memory _defaultInvestmentAssets
     )
         public
-        componentNotSet(managersToHubs[msg.sender])
     {
+        ensureComponentNotSet(managersToHubs[msg.sender]);
         associatedRegistry.reserveFundName(
             msg.sender,
             _name
@@ -131,105 +129,112 @@ contract FundFactory is AmguConsumer, Factory {
         managersToRoutes[msg.sender].mlnToken = mlnToken();
     }
 
-    function createAccounting()
-        external
-        componentSet(managersToHubs[msg.sender])
-        componentNotSet(managersToRoutes[msg.sender].accounting)
-        amguPayable(false)
-        payable
+    function _createAccountingFor(address _manager)
+        internal
     {
-        managersToRoutes[msg.sender].accounting = accountingFactory.createInstance(
-            managersToHubs[msg.sender],
-            managersToSettings[msg.sender].denominationAsset,
+        ensureComponentSet(managersToHubs[_manager]);
+        ensureComponentNotSet(managersToRoutes[_manager].accounting);
+        managersToRoutes[_manager].accounting = accountingFactory.createInstance(
+            managersToHubs[_manager],
+            managersToSettings[_manager].denominationAsset,
             associatedRegistry.nativeAsset()
         );
     }
 
-    function createFeeManager()
-        external
-        componentSet(managersToHubs[msg.sender])
-        componentNotSet(managersToRoutes[msg.sender].feeManager)
-        amguPayable(false)
-        payable
+    function createAccountingFor(address _manager) external amguPayable(false) payable { _createAccountingFor(_manager); }
+    function createAccounting() external amguPayable(false) payable { _createAccountingFor(msg.sender); }
+
+    function _createFeeManagerFor(address _manager)
+        internal
     {
-        managersToRoutes[msg.sender].feeManager = feeManagerFactory.createInstance(
-            managersToHubs[msg.sender],
-            managersToSettings[msg.sender].denominationAsset,
-            managersToSettings[msg.sender].fees,
-            managersToSettings[msg.sender].feeRates,
-            managersToSettings[msg.sender].feePeriods,
-            managersToRoutes[msg.sender].registry
+        ensureComponentSet(managersToHubs[_manager]);
+        ensureComponentNotSet(managersToRoutes[_manager].feeManager);
+        managersToRoutes[_manager].feeManager = feeManagerFactory.createInstance(
+            managersToHubs[_manager],
+            managersToSettings[_manager].denominationAsset,
+            managersToSettings[_manager].fees,
+            managersToSettings[_manager].feeRates,
+            managersToSettings[_manager].feePeriods,
+            managersToRoutes[_manager].registry
         );
     }
 
-    function createParticipation()
-        external
-        componentSet(managersToHubs[msg.sender])
-        componentNotSet(managersToRoutes[msg.sender].participation)
-        amguPayable(false)
-        payable
+    function createFeeManagerFor(address _manager) external amguPayable(false) payable { _createFeeManagerFor(_manager); }
+    function createFeeManager() external amguPayable(false) payable { _createFeeManagerFor(msg.sender); }
+
+    function _createParticipationFor(address _manager)
+        internal
     {
-        managersToRoutes[msg.sender].participation = participationFactory.createInstance(
-            managersToHubs[msg.sender],
-            managersToSettings[msg.sender].defaultInvestmentAssets,
-            managersToRoutes[msg.sender].registry
+        ensureComponentSet(managersToHubs[_manager]);
+        ensureComponentNotSet(managersToRoutes[_manager].participation);
+        managersToRoutes[_manager].participation = participationFactory.createInstance(
+            managersToHubs[_manager],
+            managersToSettings[_manager].defaultInvestmentAssets,
+            managersToRoutes[_manager].registry
         );
     }
 
-    function createPolicyManager()
-        external
-        componentSet(managersToHubs[msg.sender])
-        componentNotSet(managersToRoutes[msg.sender].policyManager)
-        amguPayable(false)
-        payable
+    function createParticipationFor(address _manager) external amguPayable(false) payable { _createParticipationFor(_manager); }
+    function createParticipation() external amguPayable(false) payable { _createParticipationFor(msg.sender); }
+
+    function _createPolicyManagerFor(address _manager)
+        internal
     {
-        managersToRoutes[msg.sender].policyManager = policyManagerFactory.createInstance(
-            managersToHubs[msg.sender]
+        ensureComponentSet(managersToHubs[_manager]);
+        ensureComponentNotSet(managersToRoutes[_manager].policyManager);
+        managersToRoutes[_manager].policyManager = policyManagerFactory.createInstance(
+            managersToHubs[_manager]
         );
     }
 
-    function createShares()
-        external
-        componentSet(managersToHubs[msg.sender])
-        componentNotSet(managersToRoutes[msg.sender].shares)
-        amguPayable(false)
-        payable
+    function createPolicyManagerFor(address _manager) external amguPayable(false) payable { _createPolicyManagerFor(_manager); }
+    function createPolicyManager() external amguPayable(false) payable { _createPolicyManagerFor(msg.sender); }
+
+    function _createSharesFor(address _manager)
+        internal
     {
-        managersToRoutes[msg.sender].shares = sharesFactory.createInstance(
-            managersToHubs[msg.sender]
+        ensureComponentSet(managersToHubs[_manager]);
+        ensureComponentNotSet(managersToRoutes[_manager].shares);
+        managersToRoutes[_manager].shares = sharesFactory.createInstance(
+            managersToHubs[_manager]
         );
     }
 
-    function createTrading()
-        external
-        componentSet(managersToHubs[msg.sender])
-        componentNotSet(managersToRoutes[msg.sender].trading)
-        amguPayable(false)
-        payable
+    function createSharesFor(address _manager) external amguPayable(false) payable { _createSharesFor(_manager); }
+    function createShares() external amguPayable(false) payable { _createSharesFor(msg.sender); }
+
+    function _createTradingFor(address _manager)
+        internal
     {
-        managersToRoutes[msg.sender].trading = tradingFactory.createInstance(
-            managersToHubs[msg.sender],
-            managersToSettings[msg.sender].exchanges,
-            managersToSettings[msg.sender].adapters,
-            managersToRoutes[msg.sender].registry
+        ensureComponentSet(managersToHubs[_manager]);
+        ensureComponentNotSet(managersToRoutes[_manager].trading);
+        managersToRoutes[_manager].trading = tradingFactory.createInstance(
+            managersToHubs[_manager],
+            managersToSettings[_manager].exchanges,
+            managersToSettings[_manager].adapters,
+            managersToRoutes[_manager].registry
         );
     }
 
-    function createVault()
-        external
-        componentSet(managersToHubs[msg.sender])
-        componentNotSet(managersToRoutes[msg.sender].vault)
-        amguPayable(false)
-        payable
+    function createTradingFor(address _manager) external amguPayable(false) payable { _createTradingFor(_manager); }
+    function createTrading() external amguPayable(false) payable { _createTradingFor(msg.sender); }
+
+    function _createVaultFor(address _manager)
+        internal
     {
-        managersToRoutes[msg.sender].vault = vaultFactory.createInstance(
-            managersToHubs[msg.sender]
+        ensureComponentSet(managersToHubs[_manager]);
+        ensureComponentNotSet(managersToRoutes[_manager].vault);
+        managersToRoutes[_manager].vault = vaultFactory.createInstance(
+            managersToHubs[_manager]
         );
     }
 
-    function completeSetup() external amguPayable(false) payable {
-        Hub.Routes memory routes = managersToRoutes[msg.sender];
-        Hub hub = Hub(managersToHubs[msg.sender]);
+    function createVaultFor(address _manager) external amguPayable(false) payable { _createVaultFor(_manager); }
+    function createVault() external amguPayable(false) payable { _createVaultFor(msg.sender); }
+
+    function _completeSetupFor(address _manager) internal {
+        Hub.Routes memory routes = managersToRoutes[_manager];
+        Hub hub = Hub(managersToHubs[_manager]);
         require(!childExists[address(hub)], "Setup already complete");
         require(
             componentExists(address(hub)) &&
@@ -263,7 +268,7 @@ contract FundFactory is AmguConsumer, Factory {
         associatedRegistry.registerFund(
             address(hub),
             msg.sender,
-            managersToSettings[msg.sender].name
+            managersToSettings[_manager].name
         );
 
         emit NewFund(
@@ -286,6 +291,9 @@ contract FundFactory is AmguConsumer, Factory {
         );
     }
 
+    function completeSetupFor(address _manager) external amguPayable(false) payable { _completeSetupFor(_manager); }
+    function completeSetup() external amguPayable(false) payable { _completeSetupFor(msg.sender); }
+
     function getFundById(uint withId) external view returns (address) { return funds[withId]; }
     function getLastFundId() external view returns (uint) { return funds.length - 1; }
 
@@ -303,4 +311,3 @@ contract FundFactory is AmguConsumer, Factory {
         return (managersToSettings[user].exchanges);
     }
 }
-


### PR DESCRIPTION
This allows DAOs to more easily setup funds, where they only need to call `beginSetup` and anyone else can continue that setup with the initiated parameters.