### PR TITLE
Refactor: allow optionally forcing a partial redeploy

### DIFF
--- a/deploy/scripts/deploy-kyber.js
+++ b/deploy/scripts/deploy-kyber.js
@@ -23,11 +23,11 @@ const main = async input => {
   const eur = fetchContract('StandardToken', input.tokens.addr.EUR);
   const knc = fetchContract('StandardToken', input.tokens.addr.KNC);
 
-  const kgtToken = await nab('BurnableToken', ['KGT', 18, 'Kyber Token'], kyberAddrs, 'KgtToken');
+  const kgtToken = await nab('BurnableToken', ['KGT', 18, 'Kyber Token'], kyberAddrs, 'KGT');
   const conversionRates = await nab('ConversionRates', [conversionRateAdmin], kyberAddrs);
   const kyberNetwork = await nab('KyberNetwork', [kyberNetworkAdmin], kyberAddrs);
   const kyberReserve = await nab('KyberReserve', [kyberNetwork.options.address, conversionRates.options.address, conf.deployer], kyberAddrs);
-  const kyberWhiteList = await nab('WhiteList', [conf.deployer, kgtToken.options.address], kyberAddrs);
+  const kyberWhiteList = await nab('WhiteList', [conf.deployer, kgtToken.options.address], kyberAddrs, 'KyberWhiteList');
   const feeBurner = await nab('FeeBurner', [conf.deployer, knc.options.address, kyberNetwork.options.address, 18], kyberAddrs);
   const expectedRate = await nab('ExpectedRate', [kyberNetwork.options.address, knc.options.address, conf.deployer], kyberAddrs);
   const kyberNetworkProxy = await nab('KyberNetworkProxy', [conf.deployer], kyberAddrs);

--- a/deploy/scripts/deploy-melon.js
+++ b/deploy/scripts/deploy-melon.js
@@ -168,9 +168,9 @@ const main = async input => {
   if (!versionInformation.exists) {
     let versionName;
     if (conf.track === 'TESTING') {
-      versionName = web3.utils.padLeft(web3.utils.toHex(melonConf.versionName), 64)
+      versionName = web3.utils.padLeft(web3.utils.toHex(`${Date.now()}`), 64);
     } else {
-      versionName = web3.utils.padLeft(web3.utils.toHex(`${Date.now()}`), 64)
+      versionName = web3.utils.padLeft(web3.utils.toHex(melonConf.versionName), 64);
     }
     await send(registry, 'registerVersion', [ version.options.address, versionName ]);
   }

--- a/deploy/scripts/deploy-system.js
+++ b/deploy/scripts/deploy-system.js
@@ -20,8 +20,15 @@ const getAllAddrs = obj => {
 
 // TODO: a more elegant way to do this?
 // pass in names of contracts that should be force redeployed
-const partialRedeploy = async (contractsToRedeploy=[]) => {
-  const deployInput = JSON.parse(fs.readFileSync(process.env.CONF));
+const partialRedeploy = async (contractsToRedeploy=[], forcePartial=false) => {
+  let deploySrcPath;
+  if (process.env.REDEPLOY_ALL === "true" && !forcePartial) {
+    deploySrcPath = process.env.DEPLOY_IN;
+  }
+  else {
+    deploySrcPath = process.env.DEPLOY_OUT;
+  }
+  const deployInput = JSON.parse(fs.readFileSync(deploySrcPath));
   Object.keys(deployInput).forEach(category => {
     if (!deployInput[category].addr) {
       return;

--- a/deploy/scripts/deploy-system.js
+++ b/deploy/scripts/deploy-system.js
@@ -39,7 +39,15 @@ const partialRedeploy = async (contractsToRedeploy=[], forcePartial=false) => {
       }
     });
   });
-  return deploySystem(deployInput);
+
+  const deploymentResult = await deploySystem(deployInput);
+
+  fs.writeFileSync(
+    process.env.DEPLOY_OUT,
+    JSON.stringify(deploymentResult.deployOut, null, '  ')
+  );
+
+  return deploymentResult;
 }
 
 const deploySystem = async input => {

--- a/deploy/utils/get-deploy-input.js
+++ b/deploy/utils/get-deploy-input.js
@@ -1,5 +1,11 @@
 const fs = require('fs');
 
-const deployIn = process.env.CONF;
+let deploySrcPath;
+if (process.env.REDEPLOY_ALL === "false") {
+  deploySrcPath = process.env.DEPLOY_OUT;
+}
+else {
+  deploySrcPath = process.env.DEPLOY_IN;
+}
 
-module.exports = JSON.parse(fs.readFileSync(deployIn, 'utf8'));
+module.exports = JSON.parse(fs.readFileSync(deploySrcPath, 'utf8'));

--- a/deploy_in_kovan.json
+++ b/deploy_in_kovan.json
@@ -44,9 +44,11 @@
       "exchangeTakesCustody": {
         "oasis": true,
         "kyber": false,
-        "zeroex": false,
+        "zeroExV2": false,
+        "zeroExV3": false,
         "ethfinex": true,
-        "engine": false
+        "engine": false,
+        "uniswap": false
       }
     }
   },
@@ -112,7 +114,6 @@
       "MLN": "",
       "BAT": "",
       "DAI": "",
-      "DGX": "",
       "EUR": "",
       "KNC": "",
       "MKR": "",
@@ -121,7 +122,7 @@
     },
     "conf": {
       "WETH": {
-        "name": "Eth Token",
+        "name": "Wrapped ether",
         "decimals": 18,
         "initialDepositAmount": "1000000000000000000"
       },
@@ -137,10 +138,6 @@
         "name": "Dai",
         "decimals": 18
       },
-      "DGX": {
-        "name": "Digix Gold Token",
-        "decimals": 9
-      },
       "EUR": {
         "name": "Euro Token",
         "decimals": 18
@@ -150,7 +147,7 @@
         "decimals": 18
       },
       "MKR": {
-        "name": "MakerDao",
+        "name": "Maker token",
         "decimals": 18
       },
       "REP": {
@@ -158,7 +155,7 @@
         "decimals": 18
       },
       "ZRX": {
-        "name": "ZeroX Protocol Token",
+        "name": "0x protocol token",
         "decimals": 18
       }
     }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "deployments/"
   ],
   "scripts": {
-    "deploy": "PRIVATE_KEYS=./keys.json CONF=./deploy_in_testing.json node deploy/scripts/deploy-system.js ./deploy_in_testing.json ./deploy_out_testing.json",
-    "deploy-kovan": "PRIVATE_KEYS=./kovan_keys.json CONF=./deploy_in_kovan.json node deploy/scripts/deploy-system.js ./deploy_in_kovan.json ./deploy_out_kovan.json",
+    "deploy": "PRIVATE_KEYS=./keys.json DEPLOY_IN=./deploy_in_testing.json DEPLOY_OUT=./deploy_out_testing.json node deploy/scripts/deploy-system.js ./deploy_in_testing.json ./deploy_out_testing.json",
+    "deploy-kovan": "PRIVATE_KEYS=./kovan_keys.json DEPLOY_IN=./deploy_in_kovan.json DEPLOY_OUT=./deploy_out_kovan.json node deploy/scripts/deploy-system.js ./deploy_in_kovan.json ./deploy_out_kovan.json",
     "devchain": "ganache-cli --gasLimit 0x989680 --defaultBalanceEther 10000000000000 -m 'exhibit now news planet fame thank swear reform tilt accident bitter axis' --networkId=4 --acctKeys ./keys.json",
     "lint": "solhint src/**/*.sol",
-    "test": "LOCAL_CHAIN=true PRIVATE_KEYS=./keys.json CONF=./deploy_in_testing.json yarn jest --runInBand --detectOpenHandles",
-    "test-kovan": "PRIVATE_KEYS=./kovan_keys.json CONF=./deploy_out_kovan.json yarn jest --testPathIgnorePatterns '/(local|tests\/mock|tests\/thirdparty)/' --runInBand"
+    "test": "LOCAL_CHAIN=true PRIVATE_KEYS=./keys.json REDEPLOY_ALL=true DEPLOY_IN=./deploy_in_testing.json DEPLOY_OUT=./deploy_out_testing.json yarn jest --runInBand --detectOpenHandles",
+    "test-kovan": "PRIVATE_KEYS=./kovan_keys.json REDEPLOY_ALL=false DEPLOY_IN=./deploy_in_kovan.json DEPLOY_OUT=./deploy_out_kovan.json yarn jest --testPathIgnorePatterns '/(local|tests\/mock|tests\/thirdparty)/' --runInBand"
   },
   "devDependencies": {
     "@0x/order-utils": "^8.5.0-beta.4",


### PR DESCRIPTION
Addresses issue #908 

This PR fixes a couple deployment bugs and allows `partialRedeploy` to optionally force partial redeployment only.

Changes in this PR:

- Fixes bugs in deployment that were causing certain contracts to always redeploy
- Updates `package.json` commands with `DEPLOY_IN`, `DEPLOY_OUT`, and `REDEPLOY_ALL` environment vars rather than `CONF` to allow granular control of when to partially redeploy
- Updates `partialRedeploy` with an optional `forcePartial` flag
- Updates `fundRiskManagement` test to use this `forcePartial` flag for creating a second fund with the same manager

Now, `partialRedeploy` will look to the config to decide whether to only redeploy partially, but only after deferring to the `forcePartial` flag.