### PR TITLE
Add compile_in.json and compile_out.json to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ out/
 .nvmrc
 .node-version
 
+# compile output
+compile_in.json
+compile_out.json
+
 # Ganache Keystore
 keys.json
 


### PR DESCRIPTION
Or is there a reason to not have them in gitignore?