### PR TITLE
Fix: Remove require condition in approval helper for exchange adapters

### DIFF
--- a/src/exchanges/libs/ExchangeAdapter.sol
+++ b/src/exchanges/libs/ExchangeAdapter.sol
@@ -21,11 +21,6 @@ abstract contract ExchangeAdapter is DSMath {
     )
         internal
     {
-        require(
-            __getAccounting().assetBalances(_asset) >= _amount,
-            string(abi.encodePacked("__approveAsset: Insufficient available assetBalance: ", _assetType))
-        );
-
         uint256 allowance = IERC20(_asset).allowance(address(this), _target);
         require(
             IERC20(_asset).approve(_target, add(allowance, _amount)),

--- a/tests/integration/fund0xV3Trading.test.js
+++ b/tests/integration/fund0xV3Trading.test.js
@@ -321,7 +321,7 @@ describe('Fund takes an order with a different taker fee asset', () => {
         callOnExchangeArgs,
         managerTxOpts
       )
-    ).rejects.toThrowFlexible("Insufficient available assetBalance: fee asset");
+    ).rejects.toThrowFlexible("TRANSFER_FAILED");
   });
 
   test('Invest in fund with enough DAI to take trade with taker fee', async () => {

--- a/tests/unit/exchanges/adapters/zeroExV3Adapter.test.js
+++ b/tests/unit/exchanges/adapters/zeroExV3Adapter.test.js
@@ -1208,24 +1208,6 @@ describe('takeOrder', () => {
         version
       });
       exchangeIndex = 0;
-
-      // Make 2nd investment with MLN to allow taker fee trade
-      takerFee = toWei('0.001', 'ether');
-      await investInFund({
-        fundAddress: fund.hub.options.address,
-        investment: {
-          contribAmount: takerFee,
-          investor: deployer,
-          tokenContract: mln
-        },
-        isInitial: false,
-        tokenPriceData: {
-          priceSource,
-          tokenAddresses: [
-            mln.options.address
-          ]
-        }
-      });
     });
     
     test('third party makes and validates an off-chain order', async () => {
@@ -1233,6 +1215,7 @@ describe('takeOrder', () => {
       const makerAssetAmount = toWei('1', 'Ether');
       const takerAssetAmount = toWei('0.05', 'Ether');
       const feeRecipientAddress = randomHex(20);
+      const takerFee = toWei('0.001', 'ether');
       takerFeeTokenAddress = mln.options.address;
       makerTokenAddress = mln.options.address;
       takerTokenAddress = weth.options.address;

--- a/tests/unit/fund/accounting/internalAccounting.test.js
+++ b/tests/unit/fund/accounting/internalAccounting.test.js
@@ -196,7 +196,7 @@ describe('trading', () => {
         ],
         defaultTxOpts
       )
-    ).rejects.toThrowFlexible("Insufficient available assetBalance: takerAsset");
+    ).rejects.toThrowFlexible("new balance cannot be less than 0");
   });
 
   it('can take a trade that decreases asset balance to exactly 0', async() => {


### PR DESCRIPTION
Some exchanges like 0x v3 might allow a user to take/make a trade even if their account does not initially have the required fee token amount. This happens in cases where the asset being received is the same as the fee asset.